### PR TITLE
[Feature] KRWT 충전 플로우 및 블록체인 Outbox 패턴 도입 

### DIFF
--- a/backend/src/main/java/org/landmark/domain/payment/controller/UserPaymentController.java
+++ b/backend/src/main/java/org/landmark/domain/payment/controller/UserPaymentController.java
@@ -1,0 +1,53 @@
+package org.landmark.domain.payment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.landmark.domain.payment.dto.ChargeRequest;
+import org.landmark.domain.payment.dto.ChargeResponse;
+import org.landmark.domain.payment.service.UserPaymentService;
+import org.landmark.global.dto.ApiResponse;
+import org.landmark.global.toss.dto.TossWebhookRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+@Tag(name = "User Payment", description = "사용자 KRWT 충전 API")
+public class UserPaymentController {
+
+    private final UserPaymentService userPaymentService;
+
+    @Operation(summary = "KRWT 충전 요청 (가상계좌 발급)")
+    @PostMapping("/charge")
+    public ApiResponse<ChargeResponse> charge(@AuthenticationPrincipal Jwt jwt,
+                                              @Valid @RequestBody ChargeRequest request) {
+        String userId = jwt.getSubject();
+        ChargeResponse response = userPaymentService.charge(userId, request);
+        return ApiResponse.created("충전 요청 생성 완료", response);
+    }
+
+    @Operation(summary = "토스페이먼츠 DEPOSIT_CALLBACK webhook")
+    @PostMapping("/webhook/toss")
+    public ResponseEntity<ApiResponse<Void>> handleTossWebhook(@RequestBody TossWebhookRequest request) {
+        log.info("토스 충전 webhook 수신 - eventType: {}, orderId: {}",
+                request.eventType(), request.data().orderId());
+
+        if (!"DONE".equals(request.data().status())) {
+            return ResponseEntity.ok(ApiResponse.ok(200, "처리 대상 아님"));
+        }
+
+        userPaymentService.completeCharge(
+                request.data().orderId(),
+                request.data().paymentKey(),
+                request.data().totalAmount()
+        );
+        return ResponseEntity.ok(ApiResponse.ok(200, "Webhook 처리 완료"));
+    }
+}

--- a/backend/src/main/java/org/landmark/domain/payment/domain/UserPayment.java
+++ b/backend/src/main/java/org/landmark/domain/payment/domain/UserPayment.java
@@ -1,0 +1,72 @@
+package org.landmark.domain.payment.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "UserPayments", indexes = {
+        @Index(name = "idx_user_payment_user_id", columnList = "user_id"),
+        @Index(name = "idx_user_payment_order_id", columnList = "toss_order_id", unique = true),
+        @Index(name = "idx_user_payment_payment_key", columnList = "toss_payment_key", unique = true)
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPayment {
+
+    @Id
+    @Column(length = 36, updatable = false, nullable = false)
+    private String id;
+
+    @Column(name = "user_id", nullable = false, length = 36)
+    private String userId;
+
+    @Column(name = "wallet_address", nullable = false, length = 42)
+    private String walletAddress;
+
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Column(name = "toss_order_id", nullable = false, length = 100)
+    private String tossOrderId;
+
+    @Column(name = "toss_payment_key", length = 200)
+    private String tossPaymentKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private UserPaymentStatus status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "paid_at")
+    private LocalDateTime paidAt;
+
+    @Builder
+    public UserPayment(String userId, String walletAddress, Long amount, String tossOrderId) {
+        this.id = UUID.randomUUID().toString();
+        this.userId = userId;
+        this.walletAddress = walletAddress;
+        this.amount = amount;
+        this.tossOrderId = tossOrderId;
+        this.status = UserPaymentStatus.PENDING;
+    }
+
+    public void markDone(String paymentKey) {
+        this.tossPaymentKey = paymentKey;
+        this.status = UserPaymentStatus.DONE;
+        this.paidAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = UserPaymentStatus.FAILED;
+    }
+}

--- a/backend/src/main/java/org/landmark/domain/payment/domain/UserPaymentStatus.java
+++ b/backend/src/main/java/org/landmark/domain/payment/domain/UserPaymentStatus.java
@@ -1,0 +1,8 @@
+package org.landmark.domain.payment.domain;
+
+public enum UserPaymentStatus {
+    PENDING,
+    DONE,
+    FAILED,
+    CANCELED
+}

--- a/backend/src/main/java/org/landmark/domain/payment/dto/ChargeRequest.java
+++ b/backend/src/main/java/org/landmark/domain/payment/dto/ChargeRequest.java
@@ -1,0 +1,8 @@
+package org.landmark.domain.payment.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ChargeRequest(
+        @NotNull @Min(1000) Long amount
+) {}

--- a/backend/src/main/java/org/landmark/domain/payment/dto/ChargeResponse.java
+++ b/backend/src/main/java/org/landmark/domain/payment/dto/ChargeResponse.java
@@ -1,0 +1,10 @@
+package org.landmark.domain.payment.dto;
+
+public record ChargeResponse(
+        String paymentId,
+        String orderId,
+        Long amount,
+        String bankName,
+        String accountNumber,
+        String expiredAt
+) {}

--- a/backend/src/main/java/org/landmark/domain/payment/repository/UserPaymentRepository.java
+++ b/backend/src/main/java/org/landmark/domain/payment/repository/UserPaymentRepository.java
@@ -1,0 +1,16 @@
+package org.landmark.domain.payment.repository;
+
+import org.landmark.domain.payment.domain.UserPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserPaymentRepository extends JpaRepository<UserPayment, String> {
+
+    Optional<UserPayment> findByTossOrderId(String tossOrderId);
+
+    Optional<UserPayment> findByTossPaymentKey(String tossPaymentKey);
+
+    List<UserPayment> findByUserIdOrderByCreatedAtDesc(String userId);
+}

--- a/backend/src/main/java/org/landmark/domain/payment/service/UserPaymentService.java
+++ b/backend/src/main/java/org/landmark/domain/payment/service/UserPaymentService.java
@@ -1,0 +1,120 @@
+package org.landmark.domain.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.landmark.domain.payment.domain.UserPayment;
+import org.landmark.domain.payment.domain.UserPaymentStatus;
+import org.landmark.domain.payment.dto.ChargeRequest;
+import org.landmark.domain.payment.dto.ChargeResponse;
+import org.landmark.domain.payment.repository.UserPaymentRepository;
+import org.landmark.domain.user.domain.User;
+import org.landmark.domain.user.repository.UserRepository;
+import org.landmark.global.blockchain.config.BlockchainConfig;
+import org.landmark.global.blockchain.outbox.service.BlockchainOutboxService;
+import org.landmark.global.constants.PaymentConstants;
+import org.landmark.global.exception.BusinessException;
+import org.landmark.global.exception.ErrorCode;
+import org.landmark.global.toss.client.TossPaymentsClient;
+import org.landmark.global.toss.dto.TossVirtualAccountRequest;
+import org.landmark.global.toss.dto.TossVirtualAccountResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserPaymentService {
+
+    private static final String AGGREGATE_TYPE = "USER_PAYMENT";
+
+    private final UserPaymentRepository paymentRepository;
+    private final UserRepository userRepository;
+    private final TossPaymentsClient tossPaymentsClient;
+    private final BlockchainOutboxService outboxService;
+    private final BlockchainConfig blockchainConfig;
+
+    /** 사용자 충전 요청 — 가상계좌 발급 후 PENDING 상태로 저장 */
+    @Transactional
+    public ChargeResponse charge(String userId, ChargeRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getWalletAddress() == null || user.getWalletAddress().isBlank()) {
+            throw new BusinessException(ErrorCode.WALLET_NOT_LINKED);
+        }
+
+        String orderId = generateOrderId(userId);
+        TossVirtualAccountRequest tossRequest = new TossVirtualAccountRequest(
+                request.amount(),
+                orderId,
+                "KRWT 충전 " + request.amount() + "원",
+                user.getName(),
+                PaymentConstants.RENTAL_VIRTUAL_ACCOUNT_VALID_HOURS,
+                PaymentConstants.DEFAULT_VIRTUAL_ACCOUNT_BANK_CODE
+        );
+        TossVirtualAccountResponse tossResponse = tossPaymentsClient.issueVirtualAccount(tossRequest);
+
+        UserPayment payment = UserPayment.builder()
+                .userId(userId)
+                .walletAddress(user.getWalletAddress())
+                .amount(request.amount())
+                .tossOrderId(orderId)
+                .build();
+        paymentRepository.save(payment);
+
+        log.info("충전 요청 생성 - userId: {}, orderId: {}, amount: {}", userId, orderId, request.amount());
+
+        return new ChargeResponse(
+                payment.getId(),
+                orderId,
+                request.amount(),
+                tossResponse.virtualAccount().bankCode(),
+                tossResponse.virtualAccount().accountNumber(),
+                tossResponse.virtualAccount().dueDate()
+        );
+    }
+
+    /**
+     * 토스 DEPOSIT_CALLBACK 웹훅 처리 — 입금 완료 시 outbox에 KRWT_MINT 등록.
+     * paymentKey 멱등성 보장.
+     */
+    @Transactional
+    public void completeCharge(String orderId, String paymentKey, Long amount) {
+        Optional<UserPayment> byKey = paymentRepository.findByTossPaymentKey(paymentKey);
+        if (byKey.isPresent() && byKey.get().getStatus() == UserPaymentStatus.DONE) {
+            log.info("이미 처리된 충전 — 스킵 (paymentKey: {})", paymentKey);
+            return;
+        }
+
+        UserPayment payment = paymentRepository.findByTossOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() == UserPaymentStatus.DONE) {
+            log.info("이미 완료된 충전 — 스킵 (orderId: {})", orderId);
+            return;
+        }
+        if (!payment.getAmount().equals(amount)) {
+            log.error("결제 금액 불일치 - orderId: {}, expected: {}, actual: {}",
+                    orderId, payment.getAmount(), amount);
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        payment.markDone(paymentKey);
+        outboxService.enqueueKrwtMint(
+                AGGREGATE_TYPE,
+                payment.getId(),
+                blockchainConfig.getKrwtTokenAddress(),
+                payment.getWalletAddress(),
+                String.valueOf(payment.getAmount())
+        );
+        log.info("충전 완료 — outbox 등록 - paymentId: {}, orderId: {}", payment.getId(), orderId);
+    }
+
+    private String generateOrderId(String userId) {
+        return "CHARGE_" + userId.substring(0, 8) + "_"
+                + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/backend/src/main/java/org/landmark/domain/reconciliation/service/ReconciliationService.java
+++ b/backend/src/main/java/org/landmark/domain/reconciliation/service/ReconciliationService.java
@@ -11,6 +11,7 @@ import org.landmark.domain.reconciliation.domain.ReconciliationType;
 import org.landmark.domain.rental.domain.RentalIncome;
 import org.landmark.domain.rental.domain.RentalIncomeStatus;
 import org.landmark.domain.rental.repository.RentalIncomeRepository;
+import org.landmark.global.scheduler.runlog.SchedulerRunLogger;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
@@ -29,6 +30,7 @@ public class ReconciliationService {
     private final RentalIncomeRepository rentalIncomeRepository;
     private final BlockchainWalletService blockchainWalletService;
     private final ReconciliationTransactionService transactionService;
+    private final SchedulerRunLogger runLogger;
 
     /**
      * 온·오프체인 보유량 대사 (매일 새벽 2시)
@@ -38,6 +40,10 @@ public class ReconciliationService {
      */
     @Scheduled(cron = "0 0 2 * * *")
     public void reconcileHoldings() {
+        runLogger.run("ReconcileHoldings", this::doReconcileHoldings);
+    }
+
+    private SchedulerRunLogger.Result doReconcileHoldings() {
         log.info("===== 온·오프체인 보유량 대사 시작 =====");
 
         List<Property> activeProperties = propertyRepository.findByStatus(PropertyStatus.ACTIVE);
@@ -70,6 +76,7 @@ public class ReconciliationService {
 
         log.info("===== 온·오프체인 보유량 대사 완료 - 검사: {}건, 불일치: {}건 =====",
                 activeProperties.size(), mismatchCount);
+        return new SchedulerRunLogger.Result(activeProperties.size(), mismatchCount);
     }
 
     /**
@@ -80,6 +87,10 @@ public class ReconciliationService {
      */
     @Scheduled(cron = "0 30 2 * * *")
     public void verifyDistributionTransactions() {
+        runLogger.run("VerifyDistributionTransactions", this::doVerifyDistributionTransactions);
+    }
+
+    private SchedulerRunLogger.Result doVerifyDistributionTransactions() {
         log.info("===== 배당 TX 검증 시작 =====");
 
         List<RentalIncome> recentDistributed = rentalIncomeRepository
@@ -115,6 +126,7 @@ public class ReconciliationService {
 
         log.info("===== 배당 TX 검증 완료 - 검사: {}건, 실패: {}건 =====",
                 recentDistributed.size(), failCount);
+        return new SchedulerRunLogger.Result(recentDistributed.size(), failCount);
     }
 
     /**
@@ -124,9 +136,13 @@ public class ReconciliationService {
      */
     @Scheduled(fixedDelay = 300000)
     public void retryFailedDistributions() {
+        runLogger.run("RetryFailedDistributions", this::doRetryFailedDistributions);
+    }
+
+    private SchedulerRunLogger.Result doRetryFailedDistributions() {
         List<RentalIncome> failedIncomes = rentalIncomeRepository.findByStatus(RentalIncomeStatus.FAILED);
 
-        if (failedIncomes.isEmpty()) return;
+        if (failedIncomes.isEmpty()) return new SchedulerRunLogger.Result(0, 0);
 
         log.info("FAILED 배당 재시도 시작 - 대상: {}건", failedIncomes.size());
 

--- a/backend/src/main/java/org/landmark/domain/reconciliation/service/ReconciliationService.java
+++ b/backend/src/main/java/org/landmark/domain/reconciliation/service/ReconciliationService.java
@@ -146,6 +146,8 @@ public class ReconciliationService {
 
         log.info("FAILED 배당 재시도 시작 - 대상: {}건", failedIncomes.size());
 
+        int processed = 0;
+        int failed = 0;
         for (RentalIncome income : failedIncomes) {
             if (!income.isRetryable()) {
                 log.warn("최대 재시도 횟수 초과 - rentalIncomeId: {}, retryCount: {}",
@@ -169,11 +171,14 @@ public class ReconciliationService {
                 // Phase 3: 성공 반영 (트랜잭션)
                 transactionService.completeRetry(income, txHash);
                 log.info("배당 재시도 성공 - rentalIncomeId: {}, txHash: {}", income.getId(), txHash);
+                processed++;
 
             } catch (Exception e) {
                 log.error("배당 재시도 실패 - rentalIncomeId: {}", income.getId(), e);
                 transactionService.failRetry(income);
+                failed++;
             }
         }
+        return new SchedulerRunLogger.Result(processed, failed);
     }
 }

--- a/backend/src/main/java/org/landmark/global/blockchain/config/BlockchainConfig.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/config/BlockchainConfig.java
@@ -33,6 +33,9 @@ public class BlockchainConfig {
     @Value("${blockchain.contract.dividend-distributor-address:}")
     private String dividendDistributorAddress;
 
+    @Value("${blockchain.contract.krwt-token-address:}")
+    private String krwtTokenAddress;
+
     /* Web3j 인스턴스 생성 */
     @Bean
     public Web3j web3j() {

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/domain/BlockchainOutbox.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/domain/BlockchainOutbox.java
@@ -1,0 +1,131 @@
+package org.landmark.global.blockchain.outbox.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "BlockchainOutbox", indexes = {
+        @Index(name = "idx_outbox_status_created", columnList = "status, created_at"),
+        @Index(name = "idx_outbox_aggregate", columnList = "aggregate_type, aggregate_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlockchainOutbox {
+
+    @Id
+    @Column(length = 36, updatable = false, nullable = false)
+    private String id;
+
+    @Column(name = "aggregate_type", nullable = false, length = 50)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", nullable = false, length = 100)
+    private String aggregateId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tx_type", nullable = false, length = 50)
+    private OutboxTxType txType;
+
+    @Column(name = "contract_address", nullable = false, length = 42)
+    private String contractAddress;
+
+    @Column(name = "to_address", length = 42)
+    private String toAddress;
+
+    @Column(name = "amount", length = 80)
+    private String amount;
+
+    @Lob
+    @Column(name = "payload")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private OutboxStatus status;
+
+    @Column(name = "nonce")
+    private Long nonce;
+
+    @Column(name = "tx_hash", length = 80)
+    private String txHash;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "last_error", length = 1000)
+    private String lastError;
+
+    @Version
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "finalized_at")
+    private LocalDateTime finalizedAt;
+
+    @Builder
+    public BlockchainOutbox(String aggregateType, String aggregateId, OutboxTxType txType,
+                            String contractAddress, String toAddress, String amount, String payload) {
+        this.id = UUID.randomUUID().toString();
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.txType = txType;
+        this.contractAddress = contractAddress;
+        this.toAddress = toAddress;
+        this.amount = amount;
+        this.payload = payload;
+        this.status = OutboxStatus.READY;
+        this.retryCount = 0;
+    }
+
+    public void markSubmitted(Long nonce, String txHash) {
+        this.status = OutboxStatus.SUBMITTED;
+        this.nonce = nonce;
+        this.txHash = txHash;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public void markConfirmed() {
+        this.status = OutboxStatus.CONFIRMED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    public void markFinalized() {
+        this.status = OutboxStatus.FINALIZED;
+        this.finalizedAt = LocalDateTime.now();
+    }
+
+    public void markFailed(String error) {
+        this.status = OutboxStatus.FAILED;
+        this.lastError = error != null && error.length() > 1000 ? error.substring(0, 1000) : error;
+        this.retryCount++;
+    }
+
+    public void markDead(String error) {
+        this.status = OutboxStatus.DEAD;
+        this.lastError = error != null && error.length() > 1000 ? error.substring(0, 1000) : error;
+    }
+
+    public void resetToReady() {
+        this.status = OutboxStatus.READY;
+    }
+
+    public boolean isRetryable(int maxRetry) {
+        return this.retryCount < maxRetry;
+    }
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/domain/OutboxStatus.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/domain/OutboxStatus.java
@@ -1,0 +1,10 @@
+package org.landmark.global.blockchain.outbox.domain;
+
+public enum OutboxStatus {
+    READY,
+    SUBMITTED,
+    CONFIRMED,
+    FINALIZED,
+    FAILED,
+    DEAD
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/domain/OutboxTxType.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/domain/OutboxTxType.java
@@ -1,0 +1,8 @@
+package org.landmark.global.blockchain.outbox.domain;
+
+public enum OutboxTxType {
+    KRWT_MINT,
+    KRWT_TRANSFER,
+    SNAPSHOT,
+    CREATE_DIVIDEND
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/repository/BlockchainOutboxRepository.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/repository/BlockchainOutboxRepository.java
@@ -1,0 +1,26 @@
+package org.landmark.global.blockchain.outbox.repository;
+
+import jakarta.persistence.LockModeType;
+import org.landmark.global.blockchain.outbox.domain.BlockchainOutbox;
+import org.landmark.global.blockchain.outbox.domain.OutboxStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.persistence.QueryHint;
+import java.util.List;
+
+public interface BlockchainOutboxRepository extends JpaRepository<BlockchainOutbox, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "-2")})
+    @Query("SELECT o FROM BlockchainOutbox o WHERE o.status = :status ORDER BY o.createdAt ASC")
+    List<BlockchainOutbox> findReadyForProcessing(@Param("status") OutboxStatus status, Pageable pageable);
+
+    List<BlockchainOutbox> findByStatusOrderByCreatedAtAsc(OutboxStatus status);
+
+    List<BlockchainOutbox> findByStatusInOrderByCreatedAtAsc(List<OutboxStatus> statuses);
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/service/BlockchainOutboxService.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/service/BlockchainOutboxService.java
@@ -1,0 +1,30 @@
+package org.landmark.global.blockchain.outbox.service;
+
+import lombok.RequiredArgsConstructor;
+import org.landmark.global.blockchain.outbox.domain.BlockchainOutbox;
+import org.landmark.global.blockchain.outbox.domain.OutboxTxType;
+import org.landmark.global.blockchain.outbox.repository.BlockchainOutboxRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlockchainOutboxService {
+
+    private final BlockchainOutboxRepository outboxRepository;
+
+    /** KRWT mint 아웃박스 등록 */
+    @Transactional
+    public BlockchainOutbox enqueueKrwtMint(String aggregateType, String aggregateId,
+                                             String krwtContractAddress, String toAddress, String amount) {
+        BlockchainOutbox outbox = BlockchainOutbox.builder()
+                .aggregateType(aggregateType)
+                .aggregateId(aggregateId)
+                .txType(OutboxTxType.KRWT_MINT)
+                .contractAddress(krwtContractAddress)
+                .toAddress(toAddress)
+                .amount(amount)
+                .build();
+        return outboxRepository.save(outbox);
+    }
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/service/OutboxTransactionService.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/service/OutboxTransactionService.java
@@ -1,0 +1,47 @@
+package org.landmark.global.blockchain.outbox.service;
+
+import lombok.RequiredArgsConstructor;
+import org.landmark.global.blockchain.outbox.domain.BlockchainOutbox;
+import org.landmark.global.blockchain.outbox.domain.OutboxStatus;
+import org.landmark.global.blockchain.outbox.repository.BlockchainOutboxRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/** Outbox worker 전용 트랜잭션 경계 서비스 */
+@Service
+@RequiredArgsConstructor
+public class OutboxTransactionService {
+
+    private final BlockchainOutboxRepository outboxRepository;
+
+    @Transactional
+    public List<BlockchainOutbox> lockReadyBatch(int batchSize) {
+        return outboxRepository.findReadyForProcessing(OutboxStatus.READY, PageRequest.of(0, batchSize));
+    }
+
+    @Transactional
+    public void markSubmitted(String id, Long nonce, String txHash) {
+        BlockchainOutbox o = outboxRepository.findById(id).orElseThrow();
+        o.markSubmitted(nonce, txHash);
+    }
+
+    @Transactional
+    public void markFailed(String id, String error, int maxRetry) {
+        BlockchainOutbox o = outboxRepository.findById(id).orElseThrow();
+        o.markFailed(error);
+        if (!o.isRetryable(maxRetry)) {
+            o.markDead(error);
+        } else {
+            o.resetToReady();
+        }
+    }
+
+    @Transactional
+    public void markConfirmed(String id) {
+        BlockchainOutbox o = outboxRepository.findById(id).orElseThrow();
+        o.markConfirmed();
+    }
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/outbox/worker/OutboxWorker.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/outbox/worker/OutboxWorker.java
@@ -1,0 +1,87 @@
+package org.landmark.global.blockchain.outbox.worker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.landmark.global.blockchain.outbox.domain.BlockchainOutbox;
+import org.landmark.global.blockchain.outbox.domain.OutboxTxType;
+import org.landmark.global.blockchain.outbox.service.OutboxTransactionService;
+import org.landmark.global.blockchain.service.BlockchainWalletService;
+import org.landmark.global.blockchain.service.NonceManager;
+import org.landmark.global.scheduler.runlog.SchedulerRunLogger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxWorker {
+
+    public static final String JOB_NAME = "BlockchainOutboxWorker";
+
+    private final OutboxTransactionService outboxTxService;
+    private final BlockchainWalletService blockchainWalletService;
+    private final NonceManager nonceManager;
+    private final SchedulerRunLogger runLogger;
+
+    @Value("${blockchain.outbox.batch-size:10}")
+    private int batchSize;
+
+    @Value("${blockchain.outbox.max-retry:5}")
+    private int maxRetry;
+
+    /**
+     * 단일 스레드 순차 실행 보장을 위해 fixedDelay 사용.
+     * @Scheduled 기본 TaskScheduler는 단일 스레드이므로 nonce 직렬화가 보장된다.
+     */
+    @Scheduled(fixedDelayString = "${blockchain.outbox.polling-interval-ms:2000}")
+    public void process() {
+        List<BlockchainOutbox> batch;
+        try {
+            batch = outboxTxService.lockReadyBatch(batchSize);
+        } catch (Exception e) {
+            log.error("Outbox batch 조회 실패", e);
+            return;
+        }
+        if (batch.isEmpty()) return;
+
+        runLogger.run(JOB_NAME, () -> {
+            int processed = 0;
+            int failed = 0;
+            for (BlockchainOutbox outbox : batch) {
+                try {
+                    dispatch(outbox);
+                    processed++;
+                } catch (Exception e) {
+                    log.error("Outbox 처리 실패 - id: {}", outbox.getId(), e);
+                    outboxTxService.markFailed(outbox.getId(), e.getMessage(), maxRetry);
+                    failed++;
+                }
+            }
+            return new SchedulerRunLogger.Result(processed, failed);
+        });
+    }
+
+    private void dispatch(BlockchainOutbox outbox) {
+        long nonce = nonceManager.nextNonce();
+        try {
+            String txHash = switch (outbox.getTxType()) {
+                case KRWT_MINT -> blockchainWalletService.mintKrwt(
+                        outbox.getToAddress(),
+                        new BigInteger(outbox.getAmount()),
+                        nonce
+                );
+                case KRWT_TRANSFER, SNAPSHOT, CREATE_DIVIDEND ->
+                        throw new UnsupportedOperationException(
+                                "아웃박스 타입 미구현: " + outbox.getTxType());
+            };
+            outboxTxService.markSubmitted(outbox.getId(), nonce, txHash);
+        } catch (Exception e) {
+            nonceManager.rollback(nonce);
+            throw e;
+        }
+    }
+}

--- a/backend/src/main/java/org/landmark/global/blockchain/service/BlockchainWalletService.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/service/BlockchainWalletService.java
@@ -17,10 +17,13 @@ import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.response.EthGetBalance;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionEncoder;
 import org.web3j.tx.RawTransactionManager;
 import org.web3j.tx.TransactionManager;
 import org.web3j.tx.gas.DefaultGasProvider;
 import org.web3j.utils.Convert;
+import org.web3j.utils.Numeric;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -74,13 +77,11 @@ public class BlockchainWalletService {
             throw new BusinessException(ErrorCode.BLOCKCHAIN_BALANCE_QUERY_FAILED);
         }
     }
-    private static final String KRWT_TOKEN_ADDRESS = "0x233E008B74e27d51a88c933F6A1b2c79C8e6A4F3";
-
     public BigInteger getKrwtBalance(String targetAddress) {
         validateInitialized();
 
+        String krwtAddress = blockchainConfig.getKrwtTokenAddress();
         log.info("KRWT 잔액 조회 시작 - targetAddress: {}", targetAddress);
-        log.info("[DEBUG] Snapshot TX FROM: {}", credentials.getAddress());
         try {
             // balanceOf(address account) 함수 정의
             Function function = new Function(
@@ -95,7 +96,7 @@ public class BlockchainWalletService {
             org.web3j.protocol.core.methods.response.EthCall response = web3j.ethCall(
                     org.web3j.protocol.core.methods.request.Transaction.createEthCallTransaction(
                             credentials.getAddress(), // 호출 주체
-                            KRWT_TOKEN_ADDRESS,      // KRWT 토큰 컨트랙트 주소
+                            krwtAddress,             // KRWT 토큰 컨트랙트 주소
                             encodedFunction),
                     DefaultBlockParameterName.LATEST
             ).send();
@@ -271,6 +272,60 @@ public class BlockchainWalletService {
             throw e;
         } catch (Exception e) {
             log.error("배당 생성 중 오류 발생 - snapshotId: {}, amount: {}", snapshotId, amount, e);
+            throw new BusinessException(ErrorCode.BLOCKCHAIN_TRANSACTION_FAILED);
+        }
+    }
+
+    /* KRWT mint — 지정 nonce로 raw transaction 전송 (영수증 대기 없음) */
+    public String mintKrwt(String toAddress, BigInteger amount, long nonce) {
+        validateInitialized();
+
+        String krwtAddress = blockchainConfig.getKrwtTokenAddress();
+        if (krwtAddress == null || krwtAddress.isEmpty()) {
+            throw new BusinessException(ErrorCode.BLOCKCHAIN_NOT_INITIALIZED);
+        }
+
+        log.info("KRWT mint 전송 - to: {}, amount: {}, nonce: {}", toAddress, amount, nonce);
+
+        Function function = new Function(
+                "mint",
+                Arrays.asList(
+                        new org.web3j.abi.datatypes.Address(toAddress),
+                        new Uint256(amount)
+                ),
+                Collections.emptyList()
+        );
+        return sendRawWithNonce(krwtAddress, FunctionEncoder.encode(function), BigInteger.valueOf(nonce));
+    }
+
+    /* 지정된 nonce로 raw transaction 서명 및 전송 (영수증 대기는 호출부에서) */
+    public String sendRawWithNonce(String contractAddress, String encodedFunction, BigInteger nonce) {
+        validateInitialized();
+        try {
+            RawTransaction rawTx = RawTransaction.createTransaction(
+                    nonce,
+                    gasProvider.getGasPrice(),
+                    gasProvider.getGasLimit(),
+                    contractAddress,
+                    BigInteger.ZERO,
+                    encodedFunction
+            );
+            byte[] signed = TransactionEncoder.signMessage(rawTx, blockchainConfig.getChainId(), credentials);
+            String hexValue = Numeric.toHexString(signed);
+
+            EthSendTransaction response = web3j.ethSendRawTransaction(hexValue).send();
+            if (response.hasError()) {
+                String msg = response.getError().getMessage();
+                log.error("Raw TX 전송 실패 - nonce: {}, error: {}", nonce, msg);
+                throw new BusinessException(ErrorCode.BLOCKCHAIN_TRANSACTION_FAILED);
+            }
+            String txHash = response.getTransactionHash();
+            log.info("Raw TX 전송 성공 - nonce: {}, txHash: {}", nonce, txHash);
+            return txHash;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Raw TX 전송 중 오류 - nonce: {}", nonce, e);
             throw new BusinessException(ErrorCode.BLOCKCHAIN_TRANSACTION_FAILED);
         }
     }

--- a/backend/src/main/java/org/landmark/global/blockchain/service/NonceManager.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/service/NonceManager.java
@@ -1,0 +1,85 @@
+package org.landmark.global.blockchain.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.landmark.global.blockchain.config.BlockchainConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+public class NonceManager {
+
+    @Nullable
+    private final Web3j web3j;
+    @Nullable
+    private final Credentials credentials;
+    private final BlockchainConfig blockchainConfig;
+    private final AtomicLong currentNonce = new AtomicLong(-1);
+
+    @Autowired
+    public NonceManager(@Nullable Web3j web3j,
+                        @Nullable Credentials credentials,
+                        BlockchainConfig blockchainConfig) {
+        this.web3j = web3j;
+        this.credentials = credentials;
+        this.blockchainConfig = blockchainConfig;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (web3j == null || credentials == null) {
+            log.warn("NonceManager 초기화 스킵 - Web3j/Credentials 미초기화");
+            return;
+        }
+        try {
+            refreshFromChain();
+            log.info("NonceManager 초기화 완료 - 시작 nonce: {}", currentNonce.get());
+        } catch (Exception e) {
+            log.error("NonceManager 초기화 실패 - chain에서 nonce 조회 불가", e);
+        }
+    }
+
+    public synchronized long nextNonce() {
+        if (currentNonce.get() < 0) {
+            refreshFromChain();
+        }
+        return currentNonce.getAndIncrement();
+    }
+
+    public synchronized void refreshFromChain() {
+        if (web3j == null || credentials == null) {
+            throw new IllegalStateException("Web3j/Credentials 미초기화");
+        }
+        try {
+            EthGetTransactionCount response = web3j.ethGetTransactionCount(
+                    credentials.getAddress(),
+                    DefaultBlockParameterName.PENDING
+            ).send();
+            BigInteger chainNonce = response.getTransactionCount();
+            currentNonce.set(chainNonce.longValue());
+            log.info("Nonce 재동기화 - address: {}, nonce: {}", credentials.getAddress(), chainNonce);
+        } catch (Exception e) {
+            throw new RuntimeException("Nonce 동기화 실패", e);
+        }
+    }
+
+    public synchronized void rollback(long failedNonce) {
+        long current = currentNonce.get();
+        if (failedNonce == current - 1) {
+            currentNonce.decrementAndGet();
+            log.warn("Nonce 롤백 - {} → {}", current, currentNonce.get());
+        } else {
+            log.warn("Nonce 롤백 스킵 (gap 발생 가능) - failed: {}, current: {}. refreshFromChain 권장",
+                    failedNonce, current);
+        }
+    }
+}

--- a/backend/src/main/java/org/landmark/global/exception/ErrorCode.java
+++ b/backend/src/main/java/org/landmark/global/exception/ErrorCode.java
@@ -28,6 +28,10 @@ public enum ErrorCode {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
   PROPERTY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 부동산 상품입니다."),
   PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 제안입니다."),
+  PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 결제 건입니다."),
+
+  // 422 — Payment / Wallet
+  WALLET_NOT_LINKED(HttpStatus.UNPROCESSABLE_ENTITY, "지갑이 연결되지 않았습니다. 먼저 지갑을 연결해주세요."),
 
   // 422 Unprocessable Entity
   ALREADY_MINTED(HttpStatus.UNPROCESSABLE_ENTITY, "이미 토큰이 발행된 부동산입니다."),

--- a/backend/src/main/java/org/landmark/global/scheduler/controller/AdminSchedulerController.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/controller/AdminSchedulerController.java
@@ -1,0 +1,40 @@
+package org.landmark.global.scheduler.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.landmark.global.dto.ApiResponse;
+import org.landmark.global.scheduler.dto.SchedulerRunLogResponse;
+import org.landmark.global.scheduler.repository.SchedulerRunLogRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/schedulers")
+@RequiredArgsConstructor
+@Tag(name = "Admin Scheduler", description = "관리자 - 스케줄러 실행 이력")
+public class AdminSchedulerController {
+
+    private final SchedulerRunLogRepository runLogRepository;
+
+    @Operation(summary = "스케줄러 실행 이력 조회", description = "최신순 정렬. jobName 파라미터로 필터링 가능.")
+    @GetMapping("/runs")
+    public ApiResponse<List<SchedulerRunLogResponse>> list(
+            @RequestParam(required = false) String jobName,
+            @RequestParam(defaultValue = "50") int size
+    ) {
+        PageRequest page = PageRequest.of(0, Math.min(size, 200));
+        List<SchedulerRunLogResponse> result = (jobName == null || jobName.isBlank()
+                ? runLogRepository.findAllByOrderByStartedAtDesc(page)
+                : runLogRepository.findByJobNameOrderByStartedAtDesc(jobName, page))
+                .stream()
+                .map(SchedulerRunLogResponse::of)
+                .toList();
+        return ApiResponse.ok(result);
+    }
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/domain/SchedulerRunLog.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/domain/SchedulerRunLog.java
@@ -1,0 +1,68 @@
+package org.landmark.global.scheduler.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "SchedulerRunLogs", indexes = {
+        @Index(name = "idx_scheduler_run_job_started", columnList = "job_name, started_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SchedulerRunLog {
+
+    @Id
+    @Column(length = 36, updatable = false, nullable = false)
+    private String id;
+
+    @Column(name = "job_name", nullable = false, length = 100)
+    private String jobName;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SchedulerRunStatus status;
+
+    @Column(name = "processed_count", nullable = false)
+    private int processedCount;
+
+    @Column(name = "failed_count", nullable = false)
+    private int failedCount;
+
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    public static SchedulerRunLog start(String jobName) {
+        SchedulerRunLog log = new SchedulerRunLog();
+        log.id = UUID.randomUUID().toString();
+        log.jobName = jobName;
+        log.startedAt = LocalDateTime.now();
+        log.status = SchedulerRunStatus.RUNNING;
+        log.processedCount = 0;
+        log.failedCount = 0;
+        return log;
+    }
+
+    public void finishSuccess(int processed, int failed) {
+        this.finishedAt = LocalDateTime.now();
+        this.status = SchedulerRunStatus.SUCCESS;
+        this.processedCount = processed;
+        this.failedCount = failed;
+    }
+
+    public void finishFailed(String error) {
+        this.finishedAt = LocalDateTime.now();
+        this.status = SchedulerRunStatus.FAILED;
+        this.errorMessage = error != null && error.length() > 1000 ? error.substring(0, 1000) : error;
+    }
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/domain/SchedulerRunStatus.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/domain/SchedulerRunStatus.java
@@ -1,0 +1,7 @@
+package org.landmark.global.scheduler.domain;
+
+public enum SchedulerRunStatus {
+    RUNNING,
+    SUCCESS,
+    FAILED
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/dto/SchedulerRunLogResponse.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/dto/SchedulerRunLogResponse.java
@@ -1,0 +1,35 @@
+package org.landmark.global.scheduler.dto;
+
+import org.landmark.global.scheduler.domain.SchedulerRunLog;
+import org.landmark.global.scheduler.domain.SchedulerRunStatus;
+
+import java.time.LocalDateTime;
+
+public record SchedulerRunLogResponse(
+        String id,
+        String jobName,
+        LocalDateTime startedAt,
+        LocalDateTime finishedAt,
+        SchedulerRunStatus status,
+        int processedCount,
+        int failedCount,
+        String errorMessage,
+        Long durationMs
+) {
+    public static SchedulerRunLogResponse of(SchedulerRunLog log) {
+        Long duration = (log.getStartedAt() != null && log.getFinishedAt() != null)
+                ? java.time.Duration.between(log.getStartedAt(), log.getFinishedAt()).toMillis()
+                : null;
+        return new SchedulerRunLogResponse(
+                log.getId(),
+                log.getJobName(),
+                log.getStartedAt(),
+                log.getFinishedAt(),
+                log.getStatus(),
+                log.getProcessedCount(),
+                log.getFailedCount(),
+                log.getErrorMessage(),
+                duration
+        );
+    }
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/repository/SchedulerRunLogRepository.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/repository/SchedulerRunLogRepository.java
@@ -1,0 +1,14 @@
+package org.landmark.global.scheduler.repository;
+
+import org.landmark.global.scheduler.domain.SchedulerRunLog;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SchedulerRunLogRepository extends JpaRepository<SchedulerRunLog, String> {
+
+    List<SchedulerRunLog> findAllByOrderByStartedAtDesc(Pageable pageable);
+
+    List<SchedulerRunLog> findByJobNameOrderByStartedAtDesc(String jobName, Pageable pageable);
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/runlog/SchedulerRunLogTransactionService.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/runlog/SchedulerRunLogTransactionService.java
@@ -1,0 +1,30 @@
+package org.landmark.global.scheduler.runlog;
+
+import lombok.RequiredArgsConstructor;
+import org.landmark.global.scheduler.domain.SchedulerRunLog;
+import org.landmark.global.scheduler.repository.SchedulerRunLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SchedulerRunLogTransactionService {
+
+    private final SchedulerRunLogRepository runLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public SchedulerRunLog saveStart(String jobName) {
+        return runLogRepository.save(SchedulerRunLog.start(jobName));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFinish(String id, int processed, int failed) {
+        runLogRepository.findById(id).ifPresent(log -> log.finishSuccess(processed, failed));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailure(String id, String error) {
+        runLogRepository.findById(id).ifPresent(log -> log.finishFailed(error));
+    }
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/runlog/SchedulerRunLogger.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/runlog/SchedulerRunLogger.java
@@ -1,0 +1,59 @@
+package org.landmark.global.scheduler.runlog;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.landmark.global.scheduler.domain.SchedulerRunLog;
+import org.landmark.global.scheduler.repository.SchedulerRunLogRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SchedulerRunLogger {
+
+    private final SchedulerRunLogRepository runLogRepository;
+
+    public record Result(int processed, int failed) {}
+
+    /**
+     * 스케줄러 작업을 실행하고 시작/종료/실패를 DB에 기록.
+     * 별도 트랜잭션으로 저장하여 작업 본체 트랜잭션과 독립.
+     */
+    public void run(String jobName, Supplier<Result> task) {
+        SchedulerRunLog runLog = saveStart(jobName);
+        try {
+            Result result = task.get();
+            saveFinish(runLog.getId(), result.processed(), result.failed());
+        } catch (Exception e) {
+            log.error("스케줄러 실행 실패 - jobName: {}", jobName, e);
+            saveFailure(runLog.getId(), e.getMessage());
+            throw e;
+        }
+    }
+
+    public void runVoid(String jobName, Runnable task) {
+        run(jobName, () -> {
+            task.run();
+            return new Result(0, 0);
+        });
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected SchedulerRunLog saveStart(String jobName) {
+        return runLogRepository.save(SchedulerRunLog.start(jobName));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void saveFinish(String id, int processed, int failed) {
+        runLogRepository.findById(id).ifPresent(log -> log.finishSuccess(processed, failed));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void saveFailure(String id, String error) {
+        runLogRepository.findById(id).ifPresent(log -> log.finishFailed(error));
+    }
+}

--- a/backend/src/main/java/org/landmark/global/scheduler/runlog/SchedulerRunLogger.java
+++ b/backend/src/main/java/org/landmark/global/scheduler/runlog/SchedulerRunLogger.java
@@ -3,10 +3,7 @@ package org.landmark.global.scheduler.runlog;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.landmark.global.scheduler.domain.SchedulerRunLog;
-import org.landmark.global.scheduler.repository.SchedulerRunLogRepository;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.function.Supplier;
 
@@ -15,22 +12,18 @@ import java.util.function.Supplier;
 @RequiredArgsConstructor
 public class SchedulerRunLogger {
 
-    private final SchedulerRunLogRepository runLogRepository;
+    private final SchedulerRunLogTransactionService txService;
 
     public record Result(int processed, int failed) {}
 
-    /**
-     * 스케줄러 작업을 실행하고 시작/종료/실패를 DB에 기록.
-     * 별도 트랜잭션으로 저장하여 작업 본체 트랜잭션과 독립.
-     */
     public void run(String jobName, Supplier<Result> task) {
-        SchedulerRunLog runLog = saveStart(jobName);
+        SchedulerRunLog runLog = txService.saveStart(jobName);
         try {
             Result result = task.get();
-            saveFinish(runLog.getId(), result.processed(), result.failed());
+            txService.saveFinish(runLog.getId(), result.processed(), result.failed());
         } catch (Exception e) {
             log.error("스케줄러 실행 실패 - jobName: {}", jobName, e);
-            saveFailure(runLog.getId(), e.getMessage());
+            txService.saveFailure(runLog.getId(), e.getMessage());
             throw e;
         }
     }
@@ -40,20 +33,5 @@ public class SchedulerRunLogger {
             task.run();
             return new Result(0, 0);
         });
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    protected SchedulerRunLog saveStart(String jobName) {
-        return runLogRepository.save(SchedulerRunLog.start(jobName));
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    protected void saveFinish(String id, int processed, int failed) {
-        runLogRepository.findById(id).ifPresent(log -> log.finishSuccess(processed, failed));
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    protected void saveFailure(String id, String error) {
-        runLogRepository.findById(id).ifPresent(log -> log.finishFailed(error));
     }
 }

--- a/backend/src/main/java/org/landmark/global/security/SecurityConfig.java
+++ b/backend/src/main/java/org/landmark/global/security/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/v3/api-docs/**",
             "/api/v1/webhook/**",
+            "/api/v1/*/webhook/**",
             "/api/v1/admin/**"
     };
 


### PR DESCRIPTION
## 📋 PR 유형
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정

<br/>

## 📕 작업 내역
 - **사용자 KRWT 충전 플로우 추가**
     - `UserPayment` 엔티티 + 레포지토리 생성 (PENDING / DONE / FAILED / CANCELED)
     - `POST /api/v1/payments/charge` — 가상계좌 발급 + 결제 PENDING 저장
     - `POST /api/v1/payments/webhook/toss` — 입금 완료 시 outbox에 `KRWT_MINT` 등록
     - 지갑 미연결 시 `WALLET_NOT_LINKED(422)` 반환
   - **블록체인 Outbox 패턴 도입 (Nonce 충돌 해결)**
     - `BlockchainOutbox` 엔티티 + `OutboxStatus` / `OutboxTxType`
     - `NonceManager` — `pending` nonce 원자 증가 + 실패 시 롤백
     - `OutboxWorker` — 단일 스레드 `@Scheduled`, `PESSIMISTIC_WRITE`로 배치 락
     - `BlockchainWalletService.mintKrwt()` + `sendRawWithNonce()` 추가
     - KRWT 토큰 주소 하드코딩 제거 → `blockchain.contract.krwt-token-address` 설정 주입
   - **스케줄러 실행 이력 기록**
     - `SchedulerRunLog` 엔티티 + `SchedulerRunLogger` / `SchedulerRunLogTransactionService`
     - 기존 `ReconciliationService` 3개 스케줄러 + 신규 `OutboxWorker` 래핑
     - `GET /api/v1/admin/schedulers/runs?jobName=&size=` 관리자 조회 API
   - **Security / 설정**
     - `/api/v1/*/webhook/**` SecurityConfig permitAll 패턴 추가 (토스 webhook 진입용)
     - `application-local.yml` — `blockchain.outbox.*` (폴링 2초, 배치 10, 재시도 5), KRWT 주소
     - `ErrorCode` — `PAYMENT_NOT_FOUND`, `WALLET_NOT_LINKED` 추가
   <br/>

   ## 🔧 앞으로의 과제
   - CONFIRMED / FINALIZED 상태 전이: Go 이벤트 리스너가 `txHash`로 outbox UPDATE하도록 인터페이스 확정
   - 월세 배당 플로우도 outbox 기반으로 리팩터

## 🚨 참고 사항
-