### PR TITLE
feat: 컨트랙트 주소 추가

### DIFF
--- a/backend/src/main/java/org/landmark/domain/properties/domain/Property.java
+++ b/backend/src/main/java/org/landmark/domain/properties/domain/Property.java
@@ -20,8 +20,14 @@ public class Property {
     @Column(name = "dao_token_address", length = 42, unique = true) //의결권(DAO) 토큰 주소
     private String daoTokenAddress;
 
-    @Column(name = "dao_contract_address", length = 42, unique = true)  // 의사결정 DAO 토큰 주소
+    @Column(name = "dao_contract_address", length = 42, unique = true)  // 의사결정 DAO 컨트랙트 주소
     private String daoContractAddress;
+
+    @Column(name = "dividend_distributor_address", length = 42, unique = true) // 배당 분배 컨트랙트 주소
+    private String dividendDistributorAddress;
+
+    @Column(name = "max_balance_module_address", length = 42, unique = true) // 최대 보유량 제한 모듈 주소
+    private String maxBalanceModuleAddress;
 
     @Column(nullable = false)
     private String name;
@@ -105,7 +111,9 @@ public class Property {
     private PropertyStatus status; // 부동산 상품의 현재 상태
 
     @Builder
-    public Property(String stoTokenAddress, String daoTokenAddress, String daoContractAddress, String name, String description, String address, String coverImageUrl,
+    public Property(String stoTokenAddress, String daoTokenAddress, String daoContractAddress,
+                    String dividendDistributorAddress, String maxBalanceModuleAddress,
+                    String name, String description, String address, String coverImageUrl,
                     BuildingType buildingType, BigDecimal exclusiveAreaSqm, Integer totalFloors,
                     String floor, Long useApprovalDate, Integer parkingSpaces,
                     String direction, Integer roomCount, Integer bathroomCount,
@@ -118,6 +126,8 @@ public class Property {
         this.id = stoTokenAddress;
         this.daoTokenAddress = daoTokenAddress;
         this.daoContractAddress = daoContractAddress;
+        this.dividendDistributorAddress = dividendDistributorAddress;
+        this.maxBalanceModuleAddress = maxBalanceModuleAddress;
         this.name = name;
         this.totalValuation = totalValuation;
         this.totalTokens = totalTokens;

--- a/backend/src/main/java/org/landmark/domain/properties/dto/PropertyCreateRequest.java
+++ b/backend/src/main/java/org/landmark/domain/properties/dto/PropertyCreateRequest.java
@@ -9,6 +9,8 @@ public record PropertyCreateRequest(
     @NotNull String stoTokenAddress,
     @NotNull String daoTokenAddress,
     @NotNull String daoContractAddress,
+    @NotNull String dividendDistributorAddress,
+    @NotNull String maxBalanceModuleAddress,
     @NotNull String name,
     String description,
     String address,
@@ -38,6 +40,8 @@ public record PropertyCreateRequest(
           .stoTokenAddress(stoTokenAddress)
           .daoTokenAddress(daoTokenAddress)
           .daoContractAddress(daoContractAddress)
+          .dividendDistributorAddress(dividendDistributorAddress)
+          .maxBalanceModuleAddress(maxBalanceModuleAddress)
           .name(name)
           .description(description)
           .address(address)

--- a/backend/src/main/java/org/landmark/domain/reconciliation/service/ReconciliationService.java
+++ b/backend/src/main/java/org/landmark/domain/reconciliation/service/ReconciliationService.java
@@ -6,6 +6,8 @@ import org.landmark.global.blockchain.service.BlockchainWalletService;
 import org.landmark.domain.portfolio.repository.UserHoldingRepository;
 import org.landmark.domain.properties.domain.Property;
 import org.landmark.domain.properties.domain.PropertyStatus;
+import org.landmark.global.exception.BusinessException;
+import org.landmark.global.exception.ErrorCode;
 import org.landmark.domain.properties.repository.PropertyRepository;
 import org.landmark.domain.reconciliation.domain.ReconciliationType;
 import org.landmark.domain.rental.domain.RentalIncome;
@@ -164,9 +166,12 @@ public class ReconciliationService {
 
                 // Phase 2: 블록체인 호출 (트랜잭션 밖)
                 String propertyTokenAddress = income.getPropertyId();
+                Property property = propertyRepository.findById(propertyTokenAddress)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.PROPERTY_NOT_FOUND));
                 BigInteger snapshotId = blockchainWalletService.createSnapshot(propertyTokenAddress);
                 BigInteger krwtAmount = income.getKrwtAmountAsBigInteger();
-                String txHash = blockchainWalletService.createDividend(snapshotId, krwtAmount);
+                String txHash = blockchainWalletService.createDividend(
+                        property.getDividendDistributorAddress(), snapshotId, krwtAmount);
 
                 // Phase 3: 성공 반영 (트랜잭션)
                 transactionService.completeRetry(income, txHash);

--- a/backend/src/main/java/org/landmark/domain/rental/service/RentalIncomeService.java
+++ b/backend/src/main/java/org/landmark/domain/rental/service/RentalIncomeService.java
@@ -6,6 +6,7 @@ import org.landmark.global.blockchain.service.BlockchainWalletService;
 import org.landmark.global.toss.client.TossPaymentsClient;
 import org.landmark.global.toss.dto.TossVirtualAccountRequest;
 import org.landmark.global.toss.dto.TossVirtualAccountResponse;
+import org.landmark.domain.properties.domain.Property;
 import org.landmark.domain.properties.repository.PropertyRepository;
 import org.landmark.domain.rental.domain.PropertyVirtualAccount;
 import org.landmark.domain.rental.domain.RentalIncome;
@@ -137,12 +138,16 @@ public class RentalIncomeService {
         String propertyTokenAddress = rentalIncome.getPropertyId();
         log.info("블록체인 배당 분배 시작 - rentalIncomeId: {}, propertyId: {}", rentalIncome.getId(), propertyTokenAddress);
 
+        Property property = propertyRepository.findById(propertyTokenAddress)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PROPERTY_NOT_FOUND));
+
         try {
             BigInteger snapshotId = blockchainWalletService.createSnapshot(propertyTokenAddress);
             log.info("Snapshot 생성 완료 - snapshotId: {}", snapshotId);
 
             BigInteger krwtAmount = rentalIncome.getKrwtAmountAsBigInteger();
-            String txHash = blockchainWalletService.createDividend(snapshotId, krwtAmount);
+            String txHash = blockchainWalletService.createDividend(
+                    property.getDividendDistributorAddress(), snapshotId, krwtAmount);
 
             // 성공: DB 업데이트 — 별도 빈의 @Transactional
             transactionService.updateDistributionSuccess(rentalIncome.getId(), txHash);

--- a/backend/src/main/java/org/landmark/global/blockchain/config/BlockchainConfig.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/config/BlockchainConfig.java
@@ -27,14 +27,23 @@ public class BlockchainConfig {
     @Value("${blockchain.wallet.private-key:}")
     private String privateKey;
 
-    @Value("${blockchain.contract.property-token-address:}")
-    private String propertyTokenAddress;
-
-    @Value("${blockchain.contract.dividend-distributor-address:}")
-    private String dividendDistributorAddress;
-
     @Value("${blockchain.contract.krwt-token-address:}")
     private String krwtTokenAddress;
+
+    @Value("${blockchain.contract.token-factory-address:}")
+    private String tokenFactoryAddress;
+
+    @Value("${blockchain.contract.identity-registry-address:}")
+    private String identityRegistryAddress;
+
+    @Value("${blockchain.contract.claim-topics-registry-address:}")
+    private String claimTopicsRegistryAddress;
+
+    @Value("${blockchain.contract.trusted-issuers-registry-address:}")
+    private String trustedIssuersRegistryAddress;
+
+    @Value("${blockchain.contract.modular-compliance-address:}")
+    private String modularComplianceAddress;
 
     /* Web3j 인스턴스 생성 */
     @Bean

--- a/backend/src/main/java/org/landmark/global/blockchain/service/BlockchainWalletService.java
+++ b/backend/src/main/java/org/landmark/global/blockchain/service/BlockchainWalletService.java
@@ -220,15 +220,15 @@ public class BlockchainWalletService {
     }
 
     /* DividendDistributor 컨트랙트의 createDividend 함수 호출 */
-    public String createDividend(BigInteger snapshotId, BigInteger amount) {
+    public String createDividend(String dividendDistributorAddress, BigInteger snapshotId, BigInteger amount) {
         validateInitialized();
 
-        if (blockchainConfig.getDividendDistributorAddress() == null ||
-            blockchainConfig.getDividendDistributorAddress().isEmpty()) {
+        if (dividendDistributorAddress == null || dividendDistributorAddress.isEmpty()) {
             throw new BusinessException(ErrorCode.BLOCKCHAIN_NOT_INITIALIZED);
         }
 
-        log.info("배당 생성 시작 - snapshotId: {}, amount: {}", snapshotId, amount);
+        log.info("배당 생성 시작 - distributorAddress: {}, snapshotId: {}, amount: {}",
+                dividendDistributorAddress, snapshotId, amount);
 
         try {
             // createDividend(uint256 snapshotId, uint256 amount) 함수
@@ -254,7 +254,7 @@ public class BlockchainWalletService {
             EthSendTransaction transactionResponse = txManager.sendTransaction(
                 gasProvider.getGasPrice(),
                 gasProvider.getGasLimit(),
-                blockchainConfig.getDividendDistributorAddress(),
+                dividendDistributorAddress,
                 encodedFunction,
                 BigInteger.ZERO
             );

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -47,8 +47,12 @@ blockchain:
   wallet:
     private-key: ${BLOCKCHAIN_WALLET_PRIVATE_KEY}
   contract:
-    property-token-address: ${BLOCKCHAIN_PROPERTY_TOKEN_ADDRESS}
-    dividend-distributor-address: ${BLOCKCHAIN_DIVIDEND_DISTRIBUTOR_ADDRESS}
+    krwt-token-address: ${BLOCKCHAIN_KRWT_TOKEN_ADDRESS}
+    token-factory-address: ${BLOCKCHAIN_TOKEN_FACTORY_ADDRESS}
+    identity-registry-address: ${BLOCKCHAIN_IDENTITY_REGISTRY_ADDRESS}
+    claim-topics-registry-address: ${BLOCKCHAIN_CLAIM_TOPICS_REGISTRY_ADDRESS}
+    trusted-issuers-registry-address: ${BLOCKCHAIN_TRUSTED_ISSUERS_REGISTRY_ADDRESS}
+    modular-compliance-address: ${BLOCKCHAIN_MODULAR_COMPLIANCE_ADDRESS}
 
 # Toss Payments Secret Key
 toss:


### PR DESCRIPTION
## 📋 PR 유형
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정

<br/>

## 📕 작업 내역
### 작업 목록
 엔티티/DTO:
  - Property - dividendDistributorAddress, maxBalanceModuleAddress 컬럼 추가
  - PropertyCreateRequest - 위 두 필드 추가 (@NotNull)

  Config:
  - BlockchainConfig - propertyTokenAddress, dividendDistributorAddress 제거 → 공용 컨트랙트 5개 추가 (tokenFactory, identityRegistry,
  claimTopicsRegistry, trustedIssuersRegistry, modularCompliance)

  서비스:
  - BlockchainWalletService.createDividend() - dividendDistributorAddress를 config에서 가져오던 것 → 파라미터로 받도록 변경
  - RentalIncomeService - Property 조회해서 dividendDistributorAddress 넘기도록 수정
  - ReconciliationService - 동일하게 수정

  yml:
  - application-local.yml - 부동산별 주소 제거, 공용 컨트랙트 주소 추가
  - application-dev.yml - 환경변수 방식으로 공용 컨트랙트 추가

  <br/>


## 🔧 앞으로의 과제
- 

## 🚨 참고 사항
-