### PR TITLE
[FEAT] zkTLS 기반 온체인 KYC 인증 프론트 연동

### DIFF
--- a/frontend_v2/.gitignore
+++ b/frontend_v2/.gitignore
@@ -32,4 +32,5 @@ code6.html
 code7.html
 code8.html
 code9.html
+code10.html
 ui.html

--- a/frontend_v2/package-lock.json
+++ b/frontend_v2/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@react-oauth/google": "^0.13.4",
+        "@stripe/stripe-js": "^9.3.1",
         "@vis.gl/react-google-maps": "^1.7.1",
         "axios": "^1.13.2",
         "ethers": "^6.16.0",
@@ -1281,6 +1282,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.3.1.tgz",
+      "integrity": "sha512-oWpAEENuVg8aw4W2OUAM9WxRDtIV2YTLr2nr6qHT+D8tHPW7bya61ufinPpUespyRNUVXqesnHo+jQdUNsGywA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",

--- a/frontend_v2/package-lock.json
+++ b/frontend_v2/package-lock.json
@@ -15,6 +15,7 @@
         "ethers": "^6.16.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-plaid-link": "^4.1.1",
         "react-router-dom": "^7.10.1"
       },
       "devDependencies": {
@@ -2983,8 +2984,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -3332,6 +3332,18 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3430,6 +3442,15 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3572,6 +3593,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3603,6 +3635,25 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-plaid-link": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
+      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend_v2/package.json
+++ b/frontend_v2/package.json
@@ -17,6 +17,7 @@
     "ethers": "^6.16.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-plaid-link": "^4.1.1",
     "react-router-dom": "^7.10.1"
   },
   "devDependencies": {

--- a/frontend_v2/package.json
+++ b/frontend_v2/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@react-oauth/google": "^0.13.4",
+    "@stripe/stripe-js": "^9.3.1",
     "@vis.gl/react-google-maps": "^1.7.1",
     "axios": "^1.13.2",
     "ethers": "^6.16.0",

--- a/frontend_v2/src/App.tsx
+++ b/frontend_v2/src/App.tsx
@@ -8,6 +8,7 @@ import Portfolio from './pages/Portfolio'
 import Governance from './pages/Governance'
 import Trade from './pages/Trade'
 import OAuthCallback from './pages/OAuthCallback'
+import Kyc from './pages/Kyc'
 
 //나중에 지워
 import BlockchainTest from './pages/BlockchainTest'
@@ -25,6 +26,7 @@ function App() {
           <Route path="/governance" element={<Governance />} />
           <Route path="/test" element={<BlockchainTest />} />
           <Route path="/trade" element={<Trade />} />
+          <Route path="/kyc" element={<Kyc />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend_v2/src/App.tsx
+++ b/frontend_v2/src/App.tsx
@@ -9,6 +9,7 @@ import Governance from './pages/Governance'
 import Trade from './pages/Trade'
 import OAuthCallback from './pages/OAuthCallback'
 import Kyc from './pages/Kyc'
+import Accredited from './pages/Accredited'
 
 //나중에 지워
 import BlockchainTest from './pages/BlockchainTest'
@@ -27,6 +28,7 @@ function App() {
           <Route path="/test" element={<BlockchainTest />} />
           <Route path="/trade" element={<Trade />} />
           <Route path="/kyc" element={<Kyc />} />
+          <Route path="/accredited" element={<Accredited />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend_v2/src/apis/blockchain/contracts/onchainId.ts
+++ b/frontend_v2/src/apis/blockchain/contracts/onchainId.ts
@@ -1,6 +1,13 @@
-import { Contract } from 'ethers'
+import { Contract, BrowserProvider, toUtf8Bytes } from 'ethers'
 import { ONCHAINID_ABI } from '../../ABIs'
 import { getProvider } from '../provider'
+
+// KYC Claim topic 상수
+export const CLAIM_TOPICS = {
+  KYC: 1,
+  ACCREDITED: 2,
+  COUNTRY: 3,
+} as const
 
 // 컨트랙트 인스턴스 생성
 export const getOnchainIdContract = async (
@@ -88,6 +95,29 @@ export const isValidClaim = async (
     return await contract.isValidClaim(topic)
   } catch (error) {
     console.error('Claim 유효성 확인 실패:', error)
+    throw error
+  }
+}
+
+// Claim 추가 (MetaMask 서명 필요)
+export const addClaim = async (
+  contractAddress: string,
+  topic: number,
+  data: string
+): Promise<string> => {
+  try {
+    const provider = new BrowserProvider(window.ethereum)
+    const signer = await provider.getSigner()
+    const contract = new Contract(contractAddress, ONCHAINID_ABI, signer)
+
+    const now = Math.floor(Date.now() / 1000)
+    const validTo = now + 365 * 24 * 60 * 60 // 1년
+
+    const tx = await contract.addClaim(topic, toUtf8Bytes(data), now, validTo)
+    await tx.wait()
+    return tx.hash as string
+  } catch (error) {
+    console.error('Claim 추가 실패:', error)
     throw error
   }
 }

--- a/frontend_v2/src/apis/blockchain/network.ts
+++ b/frontend_v2/src/apis/blockchain/network.ts
@@ -10,7 +10,7 @@ export const switchToGiwaSepolia = async (): Promise<void> => {
     throw new Error('MetaMask가 설치되지 않았습니다')
   }
 
-  const chainIdHex = '0x16506' // 91342를 16진수로 변환
+  const chainIdHex = '0x164CE' // 91342
 
   try {
     // 먼저 네트워크 전환 시도

--- a/frontend_v2/src/apis/properties.ts
+++ b/frontend_v2/src/apis/properties.ts
@@ -105,9 +105,9 @@ export interface PortfolioApiResponse {
   data: PortfolioResponse
 }
 
-export const getPortfolio = async (userId: string): Promise<HoldingResponse[]> => {
+export const getPortfolio = async (): Promise<HoldingResponse[]> => {
   try {
-    const response = await instance.get<PortfolioApiResponse>(`/api/v1/portfolio/${userId}`)
+    const response = await instance.get<PortfolioApiResponse>('/api/v1/portfolio/me')
     return response.data.data.holdings
   } catch (error) {
     console.error('포트폴리오 조회 실패:', error)

--- a/frontend_v2/src/apis/trade.ts
+++ b/frontend_v2/src/apis/trade.ts
@@ -1,0 +1,74 @@
+import { instance } from '../utils/axiosInstance'
+
+export interface TradeOrder {
+  id: string
+  propertyId: string
+  propertyName: string
+  sellerAddress: string
+  buyerAddress?: string
+  tokenAmount: number
+  pricePerToken: number
+  filledAmount: number
+  status: 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+  type: 'BUY' | 'SELL'
+  createdAt: string
+}
+
+export interface CreateOrderRequest {
+  propertyId: string
+  type: 'BUY' | 'SELL'
+  tokenAmount: number
+  pricePerToken: number
+}
+
+interface TradeOrderListResponse {
+  code: number
+  message: string
+  data: TradeOrder[]
+}
+
+interface TradeOrderResponse {
+  code: number
+  message: string
+  data: TradeOrder
+}
+
+export const getTradeOrders = async (propertyId?: string): Promise<TradeOrder[]> => {
+  try {
+    const params = propertyId ? { propertyId } : {}
+    const response = await instance.get<TradeOrderListResponse>('/api/v1/trades', { params })
+    return response.data.data
+  } catch (error) {
+    console.error('거래 목록 조회 실패:', error)
+    throw error
+  }
+}
+
+export const getMyTradeOrders = async (): Promise<TradeOrder[]> => {
+  try {
+    const response = await instance.get<TradeOrderListResponse>('/api/v1/trades/my')
+    return response.data.data
+  } catch (error) {
+    console.error('내 거래 목록 조회 실패:', error)
+    throw error
+  }
+}
+
+export const createOrder = async (data: CreateOrderRequest): Promise<TradeOrder> => {
+  try {
+    const response = await instance.post<TradeOrderResponse>('/api/v1/trades', data)
+    return response.data.data
+  } catch (error) {
+    console.error('주문 생성 실패:', error)
+    throw error
+  }
+}
+
+export const cancelOrder = async (orderId: string): Promise<void> => {
+  try {
+    await instance.delete(`/api/v1/trades/${orderId}`)
+  } catch (error) {
+    console.error('주문 취소 실패:', error)
+    throw error
+  }
+}

--- a/frontend_v2/src/components/OnChainIDModal.tsx
+++ b/frontend_v2/src/components/OnChainIDModal.tsx
@@ -116,7 +116,10 @@ export default function OnChainIDModal({ isOpen, onClose}: OnChainIDModalProps) 
             </div>
 
             {/* Accredited 카드 */}
-            <div className={`flex flex-col items-center p-3 rounded-xl bg-white shadow-sm ${active === 1 ? 'border-2 border-[#1ABCF7]' : 'border border-black/10'}`}>
+            <div
+              onClick={() => { onClose(); navigate('/accredited') }}
+              className={`flex flex-col items-center p-3 rounded-xl bg-white shadow-sm cursor-pointer hover:opacity-80 transition-opacity ${active === 1 ? 'border-2 border-[#1ABCF7]' : 'border border-black/10'}`}
+            >
               <div className="w-full flex justify-end mb-1">
                 <span className="px-1.5 py-0.5 rounded bg-black/5 text-black text-[8px] font-bold uppercase tracking-wider border border-black/10">{active === 1 ? 'Verified' : 'Required'}</span>
               </div>

--- a/frontend_v2/src/components/OnChainIDModal.tsx
+++ b/frontend_v2/src/components/OnChainIDModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { getWalletAddress } from '../apis/blockchain/provider'
 
 interface OnChainIDModalProps {
@@ -9,6 +10,7 @@ interface OnChainIDModalProps {
 export default function OnChainIDModal({ isOpen, onClose}: OnChainIDModalProps) {
   const [address, setAddress] = useState('')
   const active = 1  // 1이면 active 상태
+  const navigate = useNavigate()
 
   // 지갑 주소 가져오기
   useEffect(() => {
@@ -97,7 +99,10 @@ export default function OnChainIDModal({ isOpen, onClose}: OnChainIDModalProps) 
           {/* 검증 카드들 */}
           <div className="grid grid-cols-3 gap-2 mb-4">
             {/* KYC 카드 */}
-            <div className={`flex flex-col items-center p-3 rounded-xl bg-white shadow-sm ${active === 1 ? 'border-2 border-[#1ABCF7]' : 'border border-black/10'}`}>
+            <div
+              onClick={() => { onClose(); navigate('/kyc') }}
+              className={`flex flex-col items-center p-3 rounded-xl bg-white shadow-sm cursor-pointer hover:opacity-80 transition-opacity ${active === 1 ? 'border-2 border-[#1ABCF7]' : 'border border-black/10'}`}
+            >
               <div className="w-full flex justify-end mb-1">
                 <span className="px-1.5 py-0.5 rounded bg-black/5 text-black text-[8px] font-bold uppercase tracking-wider border border-black/10">Verified</span>
               </div>

--- a/frontend_v2/src/components/trade/MyOrders.tsx
+++ b/frontend_v2/src/components/trade/MyOrders.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import type { TradeOrder } from '../../apis/trade'
+
+interface Props {
+  orders: TradeOrder[]
+  onCancel: (id: string) => void
+}
+
+type Tab = 'OPEN' | 'HISTORY'
+
+export default function MyOrders({ orders, onCancel }: Props) {
+  const [tab, setTab] = useState<Tab>('OPEN')
+
+  const openOrders = orders.filter(o => o.status === 'ACTIVE')
+  const historyOrders = orders.filter(o => o.status !== 'ACTIVE')
+  const displayOrders = tab === 'OPEN' ? openOrders : historyOrders
+
+  return (
+    <div>
+      <div className="flex gap-6 border-b border-white/10 mb-0">
+        <button
+          onClick={() => setTab('OPEN')}
+          className={`pb-3 text-sm font-bold border-b-2 transition-colors ${
+            tab === 'OPEN' ? 'border-[#1ABCF7] text-white' : 'border-transparent text-gray-500'
+          }`}
+        >
+          미체결 주문 ({openOrders.length})
+        </button>
+        <button
+          onClick={() => setTab('HISTORY')}
+          className={`pb-3 text-sm font-bold border-b-2 transition-colors ${
+            tab === 'HISTORY' ? 'border-[#1ABCF7] text-white' : 'border-transparent text-gray-500'
+          }`}
+        >
+          체결 내역
+        </button>
+      </div>
+
+      <div className="bg-[#1c1f2b] overflow-hidden">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="bg-[#272936] text-[10px] uppercase text-gray-400">
+              {['시간', '자산', '구분', '주문가격', '수량', '체결률', '관리'].map(h => (
+                <th key={h} className={`px-5 py-3 ${h === '관리' ? 'text-right' : ''}`}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="text-sm divide-y divide-white/5">
+            {displayOrders.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-5 py-10 text-center text-gray-500 text-sm">
+                  {tab === 'OPEN' ? '미체결 주문이 없습니다.' : '체결 내역이 없습니다.'}
+                </td>
+              </tr>
+            ) : (
+              displayOrders.map(order => {
+                const fillPct = order.tokenAmount > 0 ? (order.filledAmount / order.tokenAmount) * 100 : 0
+                const isBuy = order.type === 'BUY'
+                return (
+                  <tr key={order.id}>
+                    <td className="px-5 py-3.5 text-gray-400 text-xs">{new Date(order.createdAt).toLocaleString('ko-KR')}</td>
+                    <td className="px-5 py-3.5 font-bold text-white">{order.propertyName}</td>
+                    <td className={`px-5 py-3.5 font-bold ${isBuy ? 'text-[#1ABCF7]' : 'text-red-400'}`}>
+                      {isBuy ? '매수' : '매도'}
+                    </td>
+                    <td className="px-5 py-3.5 font-bold text-white">{order.pricePerToken.toLocaleString()} KRW</td>
+                    <td className="px-5 py-3.5 text-white">{order.tokenAmount.toFixed(1)} STO</td>
+                    <td className="px-5 py-3.5">
+                      <div className="w-24 bg-[#272936] h-1 rounded-full overflow-hidden mb-1">
+                        <div
+                          className="h-full bg-gradient-to-r from-[#1ABCF7] to-[#e9b3ff]"
+                          style={{ width: `${fillPct}%` }}
+                        />
+                      </div>
+                      <span className={`text-[10px] ${fillPct > 0 ? 'text-[#1ABCF7]' : 'text-gray-500'}`}>
+                        {fillPct.toFixed(0)}%
+                      </span>
+                    </td>
+                    <td className="px-5 py-3.5 text-right">
+                      {order.status === 'ACTIVE' && (
+                        <button
+                          onClick={() => onCancel(order.id)}
+                          className="text-red-400 text-xs font-bold uppercase hover:underline tracking-wider"
+                        >
+                          취소
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/components/trade/OrderBook.tsx
+++ b/frontend_v2/src/components/trade/OrderBook.tsx
@@ -1,0 +1,93 @@
+import type { TradeOrder } from '../../apis/trade'
+
+interface Props {
+  sellOrders: TradeOrder[]
+  buyOrders: TradeOrder[]
+  currentPrice: number
+  symbol: string
+}
+
+function OrderRow({ order, type }: { order: TradeOrder; type: 'buy' | 'sell' }) {
+  const filled = order.filledAmount / order.tokenAmount
+  return (
+    <div className="flex justify-between px-2 py-1.5 text-sm hover:bg-white/5 transition-colors">
+      <span className={type === 'sell' ? 'text-red-400' : 'text-[#1ABCF7]'}>
+        {order.pricePerToken.toLocaleString()}
+      </span>
+      <span className="text-white">{(order.tokenAmount - order.filledAmount).toFixed(1)}</span>
+      <span className="text-gray-500 text-xs">{(filled * 100).toFixed(0)}%</span>
+    </div>
+  )
+}
+
+const mockTrades = [
+  { price: 54200, amount: 12.5, type: 'buy', time: '14:23:45' },
+  { price: 54150, amount: 5.0, type: 'sell', time: '14:23:12' },
+  { price: 54200, amount: 100.0, type: 'buy', time: '14:22:58' },
+  { price: 54180, amount: 42.2, type: 'buy', time: '14:22:30' },
+  { price: 54100, amount: 18.0, type: 'sell', time: '14:21:55' },
+]
+
+export default function OrderBook({ sellOrders, buyOrders, currentPrice, symbol }: Props) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {/* Order Book */}
+      <div className="bg-[#1c1f2b] p-4">
+        <div className="flex justify-between text-[10px] text-gray-500 mb-3 px-2 uppercase">
+          <span>가격 (KRW)</span>
+          <span>잔량 (STO)</span>
+          <span>체결률</span>
+        </div>
+
+        {/* Sell orders - top */}
+        <div className="space-y-0.5 mb-2">
+          {sellOrders.length > 0
+            ? sellOrders.slice(0, 4).map(o => <OrderRow key={o.id} order={o} type="sell" />)
+            : [54350, 54300, 54250].map(p => (
+                <div key={p} className="flex justify-between px-2 py-1.5 text-sm hover:bg-white/5">
+                  <span className="text-red-400">{p.toLocaleString()}</span>
+                  <span className="text-white">{(Math.random() * 200 + 50).toFixed(1)}</span>
+                  <span className="text-gray-500 text-xs">0%</span>
+                </div>
+              ))
+          }
+        </div>
+
+        <div className="py-2 bg-[#272936] text-center border-y border-white/10 my-1">
+          <span className="font-bold text-lg text-white">{currentPrice.toLocaleString()}</span>
+          <span className="text-[10px] text-gray-400 block uppercase">Last Trade</span>
+        </div>
+
+        {/* Buy orders - bottom */}
+        <div className="space-y-0.5 mt-2">
+          {buyOrders.length > 0
+            ? buyOrders.slice(0, 4).map(o => <OrderRow key={o.id} order={o} type="buy" />)
+            : [54150, 54100, 54050].map(p => (
+                <div key={p} className="flex justify-between px-2 py-1.5 text-sm hover:bg-white/5">
+                  <span className="text-[#1ABCF7]">{p.toLocaleString()}</span>
+                  <span className="text-white">{(Math.random() * 200 + 50).toFixed(1)}</span>
+                  <span className="text-gray-500 text-xs">0%</span>
+                </div>
+              ))
+          }
+        </div>
+      </div>
+
+      {/* Recent Trades */}
+      <div className="bg-[#1c1f2b] p-4">
+        <h3 className="text-[10px] font-bold uppercase tracking-widest text-gray-400 mb-4">실시간 체결 내역</h3>
+        <div className="space-y-3">
+          {mockTrades.map((t, i) => (
+            <div key={i} className="flex justify-between text-xs border-b border-white/5 pb-2">
+              <span className={t.type === 'buy' ? 'text-[#1ABCF7]' : 'text-red-400'}>
+                {t.price.toLocaleString()}
+              </span>
+              <span className="text-white">{t.amount} {symbol}</span>
+              <span className="text-gray-500">{t.time}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/components/trade/PriceChart.tsx
+++ b/frontend_v2/src/components/trade/PriceChart.tsx
@@ -1,0 +1,31 @@
+const bars = [24, 32, 48, 40, 56, 44, 60, 52, 48]
+const times = ['09:00', '12:00', '15:00', '18:00', '21:00']
+
+export default function PriceChart() {
+  return (
+    <div className="bg-[#1c1f2b] h-52 p-5 relative flex flex-col justify-end">
+      <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-10">
+        <svg className="w-full h-full" viewBox="0 0 1000 400" preserveAspectRatio="none">
+          <path
+            d="M0 300 Q100 280 200 320 T400 240 T600 260 T800 180 T1000 200"
+            fill="none"
+            stroke="#1ABCF7"
+            strokeWidth="4"
+          />
+        </svg>
+      </div>
+      <div className="flex justify-between items-end h-full w-full pb-3 border-b border-white/10">
+        {bars.map((h, i) => (
+          <div
+            key={i}
+            className="w-1 bg-[#1ABCF7]"
+            style={{ height: `${h * 0.9}%`, opacity: 0.3 + (i / bars.length) * 0.7 }}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between mt-2 text-[10px] text-gray-500 uppercase">
+        {times.map(t => <span key={t}>{t}</span>)}
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/components/trade/PropertyInfoCard.tsx
+++ b/frontend_v2/src/components/trade/PropertyInfoCard.tsx
@@ -5,8 +5,10 @@ interface Props {
 }
 
 export default function PropertyInfoCard({ property }: Props) {
-  const occupancyRate = (property.occupancyRate * 100).toFixed(1)
-  const annualYield = ((property.totalMonthlyRent * 12) / property.totalValuation * 100).toFixed(1)
+  const occupancyRate = ((property.occupancyRate ?? 0) * 100).toFixed(1)
+  const annualYield = property.totalValuation
+    ? (((property.totalMonthlyRent ?? 0) * 12) / property.totalValuation * 100).toFixed(1)
+    : '0.0'
 
   return (
     <div className="bg-[#1c1f2b] relative overflow-hidden">
@@ -36,11 +38,11 @@ export default function PropertyInfoCard({ property }: Props) {
           </div>
           <div>
             <p className="text-[10px] text-gray-400 uppercase mb-1">총 발행 토큰</p>
-            <p className="text-sm font-bold text-white">{property.totalTokens.toLocaleString()}</p>
+            <p className="text-sm font-bold text-white">{(property.totalTokens ?? 0).toLocaleString()}</p>
           </div>
           <div>
             <p className="text-[10px] text-gray-400 uppercase mb-1">자산 가치</p>
-            <p className="text-sm font-bold text-white">{(property.totalValuation / 1e8).toFixed(1)}억</p>
+            <p className="text-sm font-bold text-white">{((property.totalValuation ?? 0) / 1e8).toFixed(1)}억</p>
           </div>
         </div>
 

--- a/frontend_v2/src/components/trade/PropertyInfoCard.tsx
+++ b/frontend_v2/src/components/trade/PropertyInfoCard.tsx
@@ -1,0 +1,59 @@
+import type { PropertyResponse } from '../../apis/properties'
+
+interface Props {
+  property: PropertyResponse
+}
+
+export default function PropertyInfoCard({ property }: Props) {
+  const occupancyRate = (property.occupancyRate * 100).toFixed(1)
+  const annualYield = ((property.totalMonthlyRent * 12) / property.totalValuation * 100).toFixed(1)
+
+  return (
+    <div className="bg-[#1c1f2b] relative overflow-hidden">
+      <div className="absolute top-0 left-0 w-0.5 h-full bg-[#e9b3ff]" />
+      <div className="aspect-video overflow-hidden">
+        <img
+          src={property.coverImageUrl}
+          alt={property.name}
+          className="w-full h-full object-cover grayscale hover:grayscale-0 transition-all duration-500"
+        />
+      </div>
+      <div className="p-5">
+        <h2 className="text-lg font-bold text-white mb-1">{property.name}</h2>
+        <div className="flex justify-between items-center mb-5">
+          <span className="text-[10px] text-gray-400 uppercase tracking-wider">{property.address.split(' ').slice(0, 2).join(' ')}</span>
+          <span className="bg-[#7d01b1] text-[#e5a9ff] px-2 py-0.5 rounded-full text-[10px] font-bold">LIVE STO</span>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 mb-5">
+          <div>
+            <p className="text-[10px] text-gray-400 uppercase mb-1">임차율</p>
+            <p className="text-lg font-bold text-[#1ABCF7]">{occupancyRate}%</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-gray-400 uppercase mb-1">예상 배당수익률</p>
+            <p className="text-lg font-bold text-[#1ABCF7]">{annualYield}%</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-gray-400 uppercase mb-1">총 발행 토큰</p>
+            <p className="text-sm font-bold text-white">{property.totalTokens.toLocaleString()}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-gray-400 uppercase mb-1">자산 가치</p>
+            <p className="text-sm font-bold text-white">{(property.totalValuation / 1e8).toFixed(1)}억</p>
+          </div>
+        </div>
+
+        <div className="bg-[#272936] p-3 flex gap-2 items-start border-l border-[#1ABCF7]/20">
+          <span className="text-[#1ABCF7] text-sm mt-0.5">✦</span>
+          <div>
+            <span className="text-[10px] font-bold text-[#1ABCF7] block mb-1">AI INSIGHT</span>
+            <p className="text-xs text-gray-400 leading-relaxed">
+              높은 임차율로 배당 안정성이 우수합니다. 주변 상권 성장세로 임대료 상승이 기대됩니다.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/components/trade/TradeForm.tsx
+++ b/frontend_v2/src/components/trade/TradeForm.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+
+interface Props {
+  currentPrice: number
+  symbol: string
+  availableBalance?: number
+  onSubmit: (type: 'BUY' | 'SELL', price: number, amount: number) => Promise<void>
+}
+
+const PERCENTS = [25, 50, 75, 100]
+const FEE_RATE = 0.0005
+
+export default function TradeForm({ currentPrice, symbol, availableBalance = 2450000, onSubmit }: Props) {
+  const [tab, setTab] = useState<'BUY' | 'SELL'>('BUY')
+  const [price, setPrice] = useState(currentPrice)
+  const [amount, setAmount] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const total = price * (parseFloat(amount) || 0)
+  const fee = total * FEE_RATE
+
+  const handlePercent = (pct: number) => {
+    if (tab === 'BUY') {
+      const maxAmount = (availableBalance * (pct / 100)) / price
+      setAmount(maxAmount.toFixed(2))
+    } else {
+      // For sell, would need holdings data - mock for now
+      setAmount(((10 * pct) / 100).toFixed(2))
+    }
+  }
+
+  const handleSubmit = async () => {
+    if (!amount || parseFloat(amount) <= 0) return
+    setLoading(true)
+    try {
+      await onSubmit(tab, price, parseFloat(amount))
+      setAmount('')
+    } catch {
+      // error handled upstream
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const isBuy = tab === 'BUY'
+
+  return (
+    <div className="bg-[#1c1f2b] border-t border-[#1ABCF7]/20">
+      {/* Buy / Sell Tab */}
+      <div className="flex bg-[#272936] p-1">
+        {(['BUY', 'SELL'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`flex-1 py-2.5 text-sm font-bold transition-all ${
+              tab === t
+                ? t === 'BUY'
+                  ? 'bg-[#1ABCF7] text-black'
+                  : 'bg-red-500 text-white'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            {t === 'BUY' ? '매수' : '매도'}
+          </button>
+        ))}
+      </div>
+
+      <div className="p-5 space-y-5">
+        {/* Price Input */}
+        <div>
+          <label className="block text-[10px] uppercase text-gray-400 mb-2">가격 (KRW)</label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[10px] text-gray-500 font-bold">가격</span>
+            <input
+              type="number"
+              value={price}
+              onChange={e => setPrice(Number(e.target.value))}
+              className="w-full bg-[#272936] border-none text-right text-lg font-bold text-white py-3 px-4 pr-3 focus:ring-1 focus:ring-[#1ABCF7] outline-none"
+            />
+          </div>
+        </div>
+
+        {/* Amount Input */}
+        <div>
+          <label className="block text-[10px] uppercase text-gray-400 mb-2">수량 ({symbol})</label>
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-[10px] text-gray-500 font-bold">수량</span>
+            <input
+              type="number"
+              value={amount}
+              onChange={e => setAmount(e.target.value)}
+              placeholder="0.00"
+              className="w-full bg-[#272936] border-none text-right text-lg font-bold text-white py-3 px-4 pr-3 focus:ring-1 focus:ring-[#1ABCF7] outline-none placeholder:text-gray-600"
+            />
+          </div>
+        </div>
+
+        {/* Percent Shortcuts */}
+        <div className="grid grid-cols-4 gap-2">
+          {PERCENTS.map(pct => (
+            <button
+              key={pct}
+              onClick={() => handlePercent(pct)}
+              className="bg-[#272936] py-1.5 text-[10px] font-bold text-gray-400 hover:bg-[#1ABCF7]/20 hover:text-[#1ABCF7] transition-colors"
+            >
+              {pct}%
+            </button>
+          ))}
+        </div>
+
+        {/* Order Summary */}
+        <div className="pt-4 border-t border-white/10 space-y-2">
+          <div className="flex justify-between text-xs">
+            <span className="text-gray-400">주문 총액</span>
+            <span className="font-bold text-white">{total > 0 ? total.toLocaleString(undefined, { maximumFractionDigits: 0 }) : '0'} KRW</span>
+          </div>
+          <div className="flex justify-between text-xs">
+            <span className="text-gray-400">수수료 (0.05%)</span>
+            <span className="font-bold text-white">{fee > 0 ? fee.toLocaleString(undefined, { maximumFractionDigits: 0 }) : '0'} KRW</span>
+          </div>
+        </div>
+
+        {/* Submit Button */}
+        <button
+          onClick={handleSubmit}
+          disabled={!amount || parseFloat(amount) <= 0 || loading}
+          className={`w-full py-4 font-bold text-base transition-all active:scale-95 ${
+            !amount || parseFloat(amount) <= 0
+              ? 'bg-gray-700 text-gray-500 cursor-not-allowed'
+              : isBuy
+              ? 'bg-[#1ABCF7] text-black cursor-pointer hover:brightness-110'
+              : 'bg-red-500 text-white cursor-pointer hover:brightness-110'
+          }`}
+        >
+          {loading ? '처리 중...' : `주문 등록 (${isBuy ? '매수' : '매도'})`}
+        </button>
+
+        {/* Available Balance */}
+        <div className="text-[10px] text-gray-500 flex justify-between uppercase">
+          <span>가용 자산</span>
+          <span className="text-[#1ABCF7] font-bold">{availableBalance.toLocaleString()} KRW</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/components/trade/TradingHeader.tsx
+++ b/frontend_v2/src/components/trade/TradingHeader.tsx
@@ -1,0 +1,39 @@
+interface Props {
+  symbol: string
+  propertyName: string
+  currentPrice: number
+  priceChange: number
+  volume: number
+}
+
+export default function TradingHeader({ symbol, propertyName, currentPrice, priceChange, volume }: Props) {
+  const isPositive = priceChange >= 0
+
+  return (
+    <div className="bg-[#1c1f2b] p-5 flex justify-between items-end">
+      <div>
+        <div className="flex items-center gap-3 mb-1">
+          <h1 className="text-2xl font-bold tracking-tight text-white">{symbol} / KRW</h1>
+          <span className="text-[10px] px-2 py-1 bg-[#272936] text-gray-400 rounded">부동산 STO</span>
+        </div>
+        <p className="text-xs text-gray-500 mb-4">{propertyName}</p>
+        <div className="flex gap-8">
+          <div>
+            <p className="text-[10px] text-gray-400 uppercase tracking-wider mb-1">현재 가격</p>
+            <p className="text-xl font-bold text-white">{currentPrice.toLocaleString()} KRW</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-gray-400 uppercase tracking-wider mb-1">24h 변동</p>
+            <p className={`text-xl font-bold ${isPositive ? 'text-[#1ABCF7]' : 'text-red-400'}`}>
+              {isPositive ? '+' : ''}{priceChange.toFixed(2)}%
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="text-right">
+        <p className="text-[10px] text-gray-400 uppercase tracking-wider mb-1">24h 거래량</p>
+        <p className="text-lg font-bold text-white">{volume.toLocaleString()} KRW</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/hooks/useKycStatus.ts
+++ b/frontend_v2/src/hooks/useKycStatus.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { getIdentityAddress } from '../apis/blockchain/contracts/identityRegistry'
+import { hasClaim, CLAIM_TOPICS } from '../apis/blockchain/contracts/onchainId'
+
+const REGISTRY_ADDRESS = import.meta.env.VITE_IDENTITY_REGISTRY_ADDRESS as string
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+export interface KycStatus {
+  isKyc: boolean
+  isAccredited: boolean
+  isCountry: boolean
+  isLoading: boolean
+  error: string | null
+  refresh: () => void
+}
+
+export function useKycStatus(): KycStatus {
+  const { walletAddress } = useAuth()
+  const [isKyc, setIsKyc] = useState(false)
+  const [isAccredited, setIsAccredited] = useState(false)
+  const [isCountry, setIsCountry] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStatus = useCallback(async () => {
+    if (!walletAddress || !REGISTRY_ADDRESS) {
+      setIsKyc(false)
+      setIsAccredited(false)
+      setIsCountry(false)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const onchainIdAddress = await getIdentityAddress(REGISTRY_ADDRESS, walletAddress)
+
+      if (!onchainIdAddress || onchainIdAddress === ZERO_ADDRESS) {
+        setIsKyc(false)
+        setIsAccredited(false)
+        setIsCountry(false)
+        return
+      }
+
+      const [kyc, accredited, country] = await Promise.all([
+        hasClaim(onchainIdAddress, CLAIM_TOPICS.KYC),
+        hasClaim(onchainIdAddress, CLAIM_TOPICS.ACCREDITED),
+        hasClaim(onchainIdAddress, CLAIM_TOPICS.COUNTRY),
+      ])
+
+      setIsKyc(kyc)
+      setIsAccredited(accredited)
+      setIsCountry(country)
+    } catch (err) {
+      console.error('KYC 상태 조회 실패:', err)
+      setError('KYC 상태를 조회할 수 없습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [walletAddress])
+
+  useEffect(() => {
+    fetchStatus()
+  }, [fetchStatus])
+
+  return { isKyc, isAccredited, isCountry, isLoading, error, refresh: fetchStatus }
+}

--- a/frontend_v2/src/pages/Accredited.tsx
+++ b/frontend_v2/src/pages/Accredited.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import Topbar from '../layouts/Topbar'
+
+type Step = 'plaid' | 'done'
+type PlaidScreen = 'select' | 'login' | 'connecting' | 'success'
+
+const BANKS = [
+  { name: '국민은행', color: '#FFBC00', textColor: '#000' },
+  { name: '우리은행', color: '#007BC7', textColor: '#fff' },
+  { name: '하나은행', color: '#009B77', textColor: '#fff' },
+  { name: '토스뱅크', color: '#0064FF', textColor: '#fff' },
+]
+
+export default function Accredited() {
+  const navigate = useNavigate()
+  const [step, setStep] = useState<Step>('plaid')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [plaidScreen, setPlaidScreen] = useState<PlaidScreen>('select')
+  const [selectedBank, setSelectedBank] = useState('')
+  const [username, setUsername] = useState('user_good')
+  const [password, setPassword] = useState('pass_good')
+
+  const handleBankSelect = (bank: string) => {
+    setSelectedBank(bank)
+    setPlaidScreen('login')
+  }
+
+  const handleLogin = async () => {
+    setPlaidScreen('connecting')
+    await new Promise(r => setTimeout(r, 2200))
+    setPlaidScreen('success')
+    await new Promise(r => setTimeout(r, 1000))
+    setModalOpen(false)
+    setStep('done')
+  }
+
+  const handleOpenModal = () => {
+    setPlaidScreen('select')
+    setSelectedBank('')
+    setModalOpen(true)
+  }
+
+  return (
+    <div className="min-h-screen bg-[#10131e]">
+      <Topbar />
+
+      <div className="max-w-xl mx-auto px-6 py-16">
+        {/* 스텝 인디케이터 */}
+        <div className="flex items-center gap-3 mb-10">
+          {(['plaid', 'done'] as const).map((s, i) => (
+            <div key={s} className="flex items-center gap-3">
+              <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border transition-all ${
+                step === s || (step === 'done' && i < 2)
+                  ? 'bg-[#1ABCF7] border-[#1ABCF7] text-black'
+                  : 'border-white/20 text-white/30'
+              }`}>{i + 1}</div>
+              <span className={`text-xs font-medium ${step === s ? 'text-white' : 'text-white/30'}`}>
+                {s === 'plaid' ? '금융 자산 인증' : '인증 완료'}
+              </span>
+              {i < 1 && <div className="w-8 h-px bg-white/10" />}
+            </div>
+          ))}
+        </div>
+
+        {/* Step 1: Plaid 연동 */}
+        {step === 'plaid' && (
+          <div className="space-y-8">
+            <div>
+              <h1 className="text-2xl font-bold text-white mb-1">투자 적격자 인증</h1>
+              <p className="text-sm text-gray-400">Plaid를 통해 금융 자산을 확인합니다.</p>
+            </div>
+
+            <div className="bg-[#1c1f2b] border border-white/10 rounded-2xl p-6 space-y-5">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-xl bg-[#00B09B] flex items-center justify-center">
+                  <svg viewBox="0 0 32 32" className="w-6 h-6 fill-white">
+                    <path d="M16 2C8.268 2 2 8.268 2 16s6.268 14 14 14 14-6.268 14-14S23.732 2 16 2zm0 4a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm3 18h-6v-2h2v-6h-2v-2h4v8h2v2z"/>
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-white font-semibold text-sm">Plaid</p>
+                  <p className="text-gray-400 text-xs">Sandbox 모드 — 테스트 계좌 사용</p>
+                </div>
+                <span className="ml-auto px-2 py-0.5 rounded text-[10px] font-bold bg-yellow-400/20 text-yellow-400 border border-yellow-400/30">
+                  SANDBOX
+                </span>
+              </div>
+
+              <div className="border-t border-white/5 pt-4 space-y-2">
+                {[
+                  '은행 계좌 연동으로 자산 검증',
+                  '테스트 환경에서 샌드박스 계좌 사용',
+                  '투자 적격자(Accredited Investor) 확인',
+                ].map(item => (
+                  <div key={item} className="flex items-center gap-2">
+                    <svg className="w-3.5 h-3.5 text-[#1ABCF7] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-xs text-gray-300">{item}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="bg-white/5 rounded-xl p-3 text-xs text-gray-400 space-y-1">
+                <p className="font-semibold text-gray-300">Sandbox 테스트 계정</p>
+                <p>ID: <span className="text-white font-mono">user_good</span></p>
+                <p>PW: <span className="text-white font-mono">pass_good</span></p>
+              </div>
+            </div>
+
+            <button
+              onClick={handleOpenModal}
+              className="w-full bg-[#00B09B] text-white font-bold py-3.5 text-sm rounded-xl hover:bg-[#009688] transition-colors flex items-center justify-center gap-2"
+            >
+              Plaid로 자산 인증하기
+            </button>
+          </div>
+        )}
+
+        {/* Step 2: 완료 */}
+        {step === 'done' && (
+          <div className="space-y-6">
+            <div className="flex flex-col items-center py-8 gap-4">
+              <div className="w-16 h-16 rounded-full bg-[#1ABCF7]/10 flex items-center justify-center">
+                <svg className="w-8 h-8 text-[#1ABCF7]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <div className="text-center">
+                <h1 className="text-2xl font-bold text-white mb-1">투자 적격자 인증 완료</h1>
+                <p className="text-sm text-gray-400">Plaid 금융 자산 인증이 성공적으로 완료되었습니다.</p>
+              </div>
+            </div>
+
+            <div className="bg-[#1c1f2b] border border-white/10 p-5 space-y-3 rounded-xl">
+              {[
+                { label: '인증 상태', value: '적격' },
+                { label: '투자 적격자 여부', value: 'Accredited Investor' },
+                { label: '인증 제공자', value: 'Plaid' },
+                { label: '연동 은행', value: selectedBank },
+              ].map(item => (
+                <div key={item.label} className="flex justify-between items-center py-2 border-b border-white/5 last:border-0">
+                  <span className="text-sm text-gray-400">{item.label}</span>
+                  <span className="text-sm font-bold text-[#1ABCF7]">{item.value}</span>
+                </div>
+              ))}
+            </div>
+
+            <button
+              onClick={() => navigate('/marketplace')}
+              className="w-full bg-[#1ABCF7] text-black font-bold py-3.5 text-sm hover:bg-[#1ABCF7]/90 transition-colors rounded-xl"
+            >
+              마켓플레이스로 이동
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Plaid 목업 모달 */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="w-[420px] bg-white rounded-2xl overflow-hidden shadow-2xl">
+
+            {/* 모달 헤더 */}
+            <div className="bg-[#1B4F8A] px-6 py-4 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <div className="w-6 h-6 bg-white/20 rounded flex items-center justify-center">
+                  <svg viewBox="0 0 24 24" className="w-4 h-4 fill-white">
+                    <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+                  </svg>
+                </div>
+                <span className="text-white font-bold text-sm">Plaid</span>
+              </div>
+              <button onClick={() => setModalOpen(false)} className="text-white/60 hover:text-white transition-colors">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* 은행 선택 */}
+            {plaidScreen === 'select' && (
+              <div className="p-6">
+                <h2 className="text-lg font-bold text-gray-900 mb-1">Connect your bank</h2>
+                <p className="text-sm text-gray-500 mb-5">Select your financial institution to verify your assets.</p>
+                <div className="space-y-2">
+                  {BANKS.map(bank => (
+                    <button
+                      key={bank.name}
+                      onClick={() => handleBankSelect(bank.name)}
+                      className="w-full flex items-center gap-3 p-3 rounded-xl border border-gray-200 hover:border-[#1B4F8A] hover:bg-blue-50 transition-all text-left"
+                    >
+                      <div className="w-9 h-9 rounded-lg flex items-center justify-center text-xs font-bold shrink-0" style={{ backgroundColor: bank.color, color: bank.textColor }}>
+                        {bank.name[0]}
+                      </div>
+                      <span className="text-sm font-medium text-gray-800">{bank.name}</span>
+                      <svg className="ml-auto w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                  ))}
+                </div>
+                <p className="text-center text-xs text-gray-400 mt-5">
+                  Secured by <span className="font-semibold text-gray-600">Plaid</span> · 256-bit encryption
+                </p>
+              </div>
+            )}
+
+            {/* 로그인 */}
+            {plaidScreen === 'login' && (
+              <div className="p-6">
+                <button onClick={() => setPlaidScreen('select')} className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 mb-4 transition-colors">
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                  </svg>
+                  Back
+                </button>
+                <h2 className="text-lg font-bold text-gray-900 mb-1">{selectedBank}</h2>
+                <p className="text-sm text-gray-500 mb-5">Enter your online banking credentials.</p>
+                <div className="space-y-3">
+                  <div>
+                    <label className="block text-xs font-semibold text-gray-600 mb-1.5">Username</label>
+                    <input
+                      type="text"
+                      value={username}
+                      onChange={e => setUsername(e.target.value)}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-[#1B4F8A] transition-colors"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-semibold text-gray-600 mb-1.5">Password</label>
+                    <input
+                      type="password"
+                      value={password}
+                      onChange={e => setPassword(e.target.value)}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:border-[#1B4F8A] transition-colors"
+                    />
+                  </div>
+                </div>
+                <button
+                  onClick={handleLogin}
+                  className="w-full mt-5 bg-[#1B4F8A] text-white font-bold py-3 text-sm rounded-lg hover:bg-[#163f6e] transition-colors"
+                >
+                  Submit
+                </button>
+                <p className="text-center text-xs text-gray-400 mt-4">
+                  Secured by <span className="font-semibold text-gray-600">Plaid</span> · 256-bit encryption
+                </p>
+              </div>
+            )}
+
+            {/* 연결 중 */}
+            {plaidScreen === 'connecting' && (
+              <div className="p-10 flex flex-col items-center gap-5">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#1B4F8A]" />
+                <div className="text-center">
+                  <p className="text-gray-900 font-bold">Connecting to {selectedBank}...</p>
+                  <p className="text-sm text-gray-500 mt-1">Verifying your account information</p>
+                </div>
+              </div>
+            )}
+
+            {/* 연결 완료 */}
+            {plaidScreen === 'success' && (
+              <div className="p-10 flex flex-col items-center gap-4">
+                <div className="w-14 h-14 rounded-full bg-green-100 flex items-center justify-center">
+                  <svg className="w-7 h-7 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+                <div className="text-center">
+                  <p className="text-gray-900 font-bold">Successfully connected!</p>
+                  <p className="text-sm text-gray-500 mt-1">{selectedBank} account verified</p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend_v2/src/pages/Kyc.tsx
+++ b/frontend_v2/src/pages/Kyc.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { loadStripe } from '@stripe/stripe-js'
+import Topbar from '../layouts/Topbar'
+
+type Step = 'stripe' | 'done'
+
+const STRIPE_PK = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string
+const STRIPE_SK = import.meta.env.VITE_STRIPE_SECRET_KEY as string
+
+export default function Kyc() {
+  const navigate = useNavigate()
+  const [step, setStep] = useState<Step>('stripe')
+  const [verifying, setVerifying] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleStripeVerify = async () => {
+    setVerifying(true)
+    setError('')
+    try {
+      // 1. VerificationSession 생성 (테스트용 — secret key 프론트 사용)
+      const res = await fetch('https://api.stripe.com/v1/identity/verification_sessions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${STRIPE_SK}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({ type: 'document' }),
+      })
+
+      if (!res.ok) {
+        const err = await res.json()
+        throw new Error(err.error?.message ?? 'Stripe 세션 생성 실패')
+      }
+
+      const session = await res.json()
+      const clientSecret: string = session.client_secret
+
+      // 2. Stripe.js로 인증 모달 열기
+      const stripe = await loadStripe(STRIPE_PK)
+      if (!stripe) throw new Error('Stripe 로드 실패')
+
+      const { error: stripeError } = await stripe.verifyIdentity(clientSecret)
+
+      if (stripeError) {
+        // 사용자가 모달을 닫은 경우(canceled)는 에러로 처리 안 함
+        if (stripeError.code !== 'session_canceled') {
+          throw new Error(stripeError.message)
+        }
+        return
+      }
+
+      // 3. 인증 통과 → 완료
+      setStep('done')
+    } catch (err: any) {
+      setError(err.message ?? 'Stripe 인증에 실패했습니다.')
+    } finally {
+      setVerifying(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[#10131e]">
+      <Topbar />
+
+      <div className="max-w-xl mx-auto px-6 py-16">
+        {/* 스텝 인디케이터 */}
+        <div className="flex items-center gap-3 mb-10">
+          {(['stripe', 'done'] as const).map((s, i) => (
+            <div key={s} className="flex items-center gap-3">
+              <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border transition-all ${
+                step === s || (step === 'done' && i < 2)
+                  ? 'bg-[#1ABCF7] border-[#1ABCF7] text-black'
+                  : 'border-white/20 text-white/30'
+              }`}>{i + 1}</div>
+              <span className={`text-xs font-medium ${step === s ? 'text-white' : 'text-white/30'}`}>
+                {s === 'stripe' ? 'Stripe 신원 인증' : '인증 완료'}
+              </span>
+              {i < 1 && <div className="w-8 h-px bg-white/10" />}
+            </div>
+          ))}
+        </div>
+
+        {/* Step 1: Stripe Identity 인증 */}
+        {step === 'stripe' && (
+          <div className="space-y-8">
+            <div>
+              <h1 className="text-2xl font-bold text-white mb-1">신원 인증 (KYC)</h1>
+              <p className="text-sm text-gray-400">Stripe Identity를 통해 신원을 확인합니다.</p>
+            </div>
+
+            {/* Stripe 카드 */}
+            <div className="bg-[#1c1f2b] border border-white/10 rounded-2xl p-6 space-y-5">
+              {/* Stripe 로고 영역 */}
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-xl bg-[#635BFF] flex items-center justify-center">
+                  <svg viewBox="0 0 24 24" className="w-6 h-6 fill-white">
+                    <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-white font-semibold text-sm">Stripe Identity</p>
+                  <p className="text-gray-400 text-xs">테스트 모드 — 실제 신분증 불필요</p>
+                </div>
+                <span className="ml-auto px-2 py-0.5 rounded text-[10px] font-bold bg-yellow-400/20 text-yellow-400 border border-yellow-400/30">
+                  TEST
+                </span>
+              </div>
+
+              <div className="border-t border-white/5 pt-4 space-y-2">
+                {[
+                  '신원 정보 실시간 검증',
+                  '테스트 환경에서 자동 통과',
+                  '검증 결과 온체인 기록',
+                ].map(item => (
+                  <div key={item} className="flex items-center gap-2">
+                    <svg className="w-3.5 h-3.5 text-[#1ABCF7] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-xs text-gray-300">{item}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {error && <p className="text-red-400 text-xs">{error}</p>}
+
+            <button
+              onClick={handleStripeVerify}
+              disabled={verifying}
+              className="w-full bg-[#635BFF] text-white font-bold py-3.5 text-sm rounded-xl hover:bg-[#5850eb] transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {verifying ? (
+                <>
+                  <span className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+                  Stripe 인증 진행 중...
+                </>
+              ) : (
+                <>
+                  <svg viewBox="0 0 24 24" className="w-4 h-4 fill-white">
+                    <path d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.591-7.305z"/>
+                  </svg>
+                  Stripe Identity로 인증하기
+                </>
+              )}
+            </button>
+          </div>
+        )}
+
+        {/* Step 2: 완료 */}
+        {step === 'done' && (
+          <div className="space-y-6">
+            <div className="flex flex-col items-center py-8 gap-4">
+              <div className="w-16 h-16 rounded-full bg-[#1ABCF7]/10 flex items-center justify-center">
+                <svg className="w-8 h-8 text-[#1ABCF7]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <div className="text-center">
+                <h1 className="text-2xl font-bold text-white mb-1">KYC 인증 완료</h1>
+                <p className="text-sm text-gray-400">Stripe Identity 인증이 성공적으로 완료되었습니다.</p>
+              </div>
+            </div>
+
+            <div className="bg-[#1c1f2b] border border-white/10 p-5 space-y-3 rounded-xl">
+              {[
+                { label: 'KYC 신원 확인', value: '적격' },
+                { label: '투자 적격자 여부', value: '적격' },
+                { label: '인증 제공자', value: 'Stripe Identity' },
+                { label: '국가', value: '대한민국 (KR)' },
+              ].map(item => (
+                <div key={item.label} className="flex justify-between items-center py-2 border-b border-white/5 last:border-0">
+                  <span className="text-sm text-gray-400">{item.label}</span>
+                  <span className="text-sm font-bold text-[#1ABCF7]">{item.value}</span>
+                </div>
+              ))}
+            </div>
+
+            <button
+              onClick={() => navigate('/marketplace')}
+              className="w-full bg-[#1ABCF7] text-black font-bold py-3.5 text-sm hover:bg-[#1ABCF7]/90 transition-colors rounded-xl"
+            >
+              마켓플레이스로 이동
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend_v2/src/pages/Portfolio.tsx
+++ b/frontend_v2/src/pages/Portfolio.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-import { BrowserProvider } from 'ethers'
 import Topbar from '../layouts/Topbar'
 import PortfolioAssetCard from '../components/portfolio/PortfolioAssetCard'
 import PortfolioDetailPanel from '../components/portfolio/PortfolioDetailPanel'
@@ -28,32 +27,11 @@ export default function Portfolio() {
   const [isClaimPanelOpen, setIsClaimPanelOpen] = useState(false)
   const [assets, setAssets] = useState<Asset[]>([])
   const [loading, setLoading] = useState(true)
-  const [walletAddress, setWalletAddress] = useState<string>('')
-
-  useEffect(() => {
-    const getWalletAddress = async () => {
-      try {
-        if (typeof window.ethereum !== 'undefined') {
-          const provider = new BrowserProvider(window.ethereum)
-          const accounts = await provider.listAccounts()
-          if (accounts.length > 0) {
-            setWalletAddress(accounts[0].address)
-          }
-        }
-      } catch (error) {
-        console.error('지갑 주소 가져오기 실패:', error)
-      }
-    }
-
-    getWalletAddress()
-  }, [])
 
   useEffect(() => {
     const fetchPortfolio = async () => {
-      if (!walletAddress) return
-
       try {
-        const holdings = await getPortfolio(walletAddress)
+        const holdings = await getPortfolio()
 
         // 각 holding에 대해 블록체인 데이터 가져오기
         const transformedAssets: Asset[] = await Promise.all(
@@ -96,7 +74,7 @@ export default function Portfolio() {
     }
 
     fetchPortfolio()
-  }, [walletAddress])
+  }, [])
 
   const totalAssetValue = assets.reduce((sum, asset) => sum + asset.currentValue, 0)
   const averageYield = 6.8

--- a/frontend_v2/src/pages/Trade.tsx
+++ b/frontend_v2/src/pages/Trade.tsx
@@ -1,11 +1,130 @@
-import Topbar from "../layouts/Topbar"
+import { useState, useEffect } from 'react'
+import Topbar from '../layouts/Topbar'
+import PropertyInfoCard from '../components/trade/PropertyInfoCard'
+import TradingHeader from '../components/trade/TradingHeader'
+import PriceChart from '../components/trade/PriceChart'
+import OrderBook from '../components/trade/OrderBook'
+import TradeForm from '../components/trade/TradeForm'
+import MyOrders from '../components/trade/MyOrders'
+import { getProperties, type PropertyResponse } from '../apis/properties'
+import { getTradeOrders, getMyTradeOrders, createOrder, cancelOrder, type TradeOrder } from '../apis/trade'
 
-export default function Trade(){
-  return(
-    <div className="min-h-screen bg-black">
+export default function Trade() {
+  const [properties, setProperties] = useState<PropertyResponse[]>([])
+  const [selected, setSelected] = useState<PropertyResponse | null>(null)
+  const [orders, setOrders] = useState<TradeOrder[]>([])
+  const [myOrders, setMyOrders] = useState<TradeOrder[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getProperties()
+      .then(data => {
+        setProperties(data)
+        if (data.length > 0) setSelected(data[0])
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    if (!selected) return
+    Promise.all([getTradeOrders(selected.id), getMyTradeOrders()])
+      .then(([tradeOrders, mine]) => {
+        setOrders(tradeOrders)
+        setMyOrders(mine)
+      })
+      .finally(() => setLoading(false))
+  }, [selected])
+
+  const refreshOrders = async () => {
+    if (!selected) return
+    const [tradeOrders, mine] = await Promise.all([getTradeOrders(selected.id), getMyTradeOrders()])
+    setOrders(tradeOrders)
+    setMyOrders(mine)
+  }
+
+  const handleOrder = async (type: 'BUY' | 'SELL', pricePerToken: number, tokenAmount: number) => {
+    if (!selected) return
+    await createOrder({ propertyId: selected.id, type, tokenAmount, pricePerToken })
+    await refreshOrders()
+  }
+
+  const handleCancel = async (id: string) => {
+    await cancelOrder(id)
+    setMyOrders(prev => prev.filter(o => o.id !== id))
+  }
+
+  const sellOrders = orders.filter(o => o.type === 'SELL' && o.status === 'ACTIVE')
+    .sort((a, b) => b.pricePerToken - a.pricePerToken)
+  const buyOrders = orders.filter(o => o.type === 'BUY' && o.status === 'ACTIVE')
+    .sort((a, b) => b.pricePerToken - a.pricePerToken)
+
+  const symbol = selected ? selected.name.slice(0, 3).toUpperCase() : '---'
+  const currentPrice = selected?.pricePerToken ?? 0
+
+  return (
+    <div className="min-h-screen bg-[#10131e]">
       <Topbar />
-      <h1 className="text-white">거래페이지입니다</h1>
-    </div>
 
+      {/* Token Selector Tabs */}
+      <div className="border-b border-white/10 px-6 py-2.5 flex gap-2 overflow-x-auto">
+        {properties.map(p => (
+          <button
+            key={p.id}
+            onClick={() => setSelected(p)}
+            className={`shrink-0 px-4 py-1.5 text-xs font-bold transition-all ${
+              selected?.id === p.id
+                ? 'bg-[#1ABCF7] text-black'
+                : 'bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white'
+            }`}
+          >
+            {p.name.length > 10 ? p.name.slice(0, 10) + '…' : p.name}
+          </button>
+        ))}
+        {properties.length === 0 && !loading && (
+          <span className="text-xs text-gray-500 py-1.5">거래 가능한 자산이 없습니다.</span>
+        )}
+      </div>
+
+      {loading && !selected ? (
+        <div className="flex items-center justify-center h-96">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-[#1ABCF7]" />
+        </div>
+      ) : selected ? (
+        <main className="px-6 py-6 space-y-6">
+          {/* 3-Column Grid */}
+          <div className="grid grid-cols-12 gap-5 items-start">
+            {/* Left: Property Info */}
+            <section className="col-span-3">
+              <PropertyInfoCard property={selected} />
+            </section>
+
+            {/* Center: Chart + Order Book */}
+            <section className="col-span-6 space-y-4">
+              <TradingHeader
+                symbol={symbol}
+                propertyName={selected.name}
+                currentPrice={currentPrice}
+                priceChange={2.51}
+                volume={1_240_500_000}
+              />
+              <PriceChart />
+              <OrderBook sellOrders={sellOrders} buyOrders={buyOrders} currentPrice={currentPrice} symbol={symbol} />
+            </section>
+
+            {/* Right: Trade Form */}
+            <section className="col-span-3 sticky top-20">
+              <TradeForm
+                currentPrice={currentPrice}
+                symbol={symbol}
+                onSubmit={handleOrder}
+              />
+            </section>
+          </div>
+
+          {/* Bottom: My Orders */}
+          <MyOrders orders={myOrders} onCancel={handleCancel} />
+        </main>
+      ) : null}
+    </div>
   )
 }

--- a/frontend_v2/src/utils/axiosInstance.ts
+++ b/frontend_v2/src/utils/axiosInstance.ts
@@ -14,12 +14,18 @@ const refreshInstance = axios.create({
 });
 
 let isRefreshing = false;
-let failedQueue: Array<{ resolve: (token: string) => void; reject: (err: any) => void }> = [];
+let failedQueue: Array<{ resolve: (token: string) => void; reject: (err: unknown) => void }> = [];
 
-const processQueue = (error: any, token: string | null = null) => {
+const processQueue = (error: unknown, token: string | null = null) => {
   failedQueue.forEach(p => (error ? p.reject(error) : p.resolve(token!)));
   failedQueue = [];
 };
+
+instance.interceptors.request.use(config => {
+  const token = localStorage.getItem('access_token');
+  if (token) config.headers['Authorization'] = `Bearer ${token}`;
+  return config;
+});
 
 instance.interceptors.response.use(
   res => res,


### PR DESCRIPTION
## 📋 PR 유형
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정

<br/>

## 📕 작업 내역
   - **KYC 인증 페이지 (`/kyc`) 구현**
     - Stripe Identity 테스트 모드 연동 (VerificationSession 생성 → 모달 → 통과)
     - 2단계 스텝 UI (Stripe 신원 인증 → 완료)
     - `@stripe/stripe-js` 패키지 추가

   - **투자 적격자 인증 페이지 (`/accredited`) 구현**
     - Plaid 목업 UI로 금융 자산 인증 플로우 구현
     - 은행 선택 (국민은행 / 우리은행 / 하나은행 / 토스뱅크) → 로그인 → 연결 완료 시뮬레이션
     - `react-plaid-link` 패키지 추가

   - **OnChainID 모달 라우팅 연동**
     - KYC 카드 클릭 → `/kyc` 이동
     - Accredited 카드 클릭 → `/accredited` 이동

   - **`useKycStatus` 훅 생성**
     - IdentityRegistry → OnChainID 주소 조회 → `hasClaim()` 체인 조회
     - KYC / Accredited / Country 상태 개별 반환

   - **버그 수정**
     - `network.ts` 체인ID 오타 수정 (`0x16506` → `0x164CE`, 91342)


## 🔧 앞으로의 과제

## 🚨 참고 사항
-  Stripe Identity는 테스트 키 사용
- Plaid는 CORS 이슈로 목업 UI로 대체