### PR TITLE
[FEAT/FIX] 배당 클레임 블록체인 연동 및 버그 수정

### DIFF
--- a/frontend_v2/src/apis/blockchain/contracts/dividendDistributor.ts
+++ b/frontend_v2/src/apis/blockchain/contracts/dividendDistributor.ts
@@ -86,10 +86,15 @@ export const getDividendInfo = async (
   try {
     const contract = await getDividendDistributorContract(contractAddress)
 
-    const [dividend, unclaimedAmount] = await Promise.all([
-      contract.dividends(dividendId),
-      contract.getUnclaimedAmount(dividendId),
-    ])
+    const dividend = await contract.dividends(dividendId)
+
+    let unclaimedAmount = '0'
+    try {
+      const raw = await contract.getUnclaimedAmount(dividendId)
+      unclaimedAmount = raw.toString()
+    } catch {
+      // 컨트랙트 오버플로우 등 내부 에러 시 0으로 처리
+    }
 
     return {
       snapshotId: dividend[0].toString(),
@@ -98,7 +103,7 @@ export const getDividendInfo = async (
       claimedAmount: dividend[3].toString(),
       timestamp: dividend[4].toString(),
       active: dividend[5],
-      unclaimedAmount: unclaimedAmount.toString(),
+      unclaimedAmount,
     }
   } catch (error) {
     console.error('배당 정보 조회 실패:', error)

--- a/frontend_v2/src/apis/blockchain/contracts/propertyToken.ts
+++ b/frontend_v2/src/apis/blockchain/contracts/propertyToken.ts
@@ -121,6 +121,16 @@ export const getUserBalance = async (
   return balance.toString()
 }
 
+export const getBalanceAtSnapshot = async (
+  contractAddress: string,
+  userAddress: string,
+  snapshotId: number
+): Promise<string> => {
+  const contract = await getPropertyContract(contractAddress)
+  const balance = await contract.balanceOfAt(userAddress, snapshotId)
+  return balance.toString()
+}
+
 
 // ============================================
 //       6. 전체 정보 한번에 조회

--- a/frontend_v2/src/apis/blockchain/contracts/tokenFactory.ts
+++ b/frontend_v2/src/apis/blockchain/contracts/tokenFactory.ts
@@ -5,6 +5,11 @@ import { getProvider } from '../provider'
 // TokenFactory 컨트랙트 주소 (환경변수나 config에서 가져오거나 하드코딩)
 const TOKEN_FACTORY_ADDRESS = '0x4959CF91F289D61BEA0f177f18291b94dC4Bed35' // 실제 주소
 
+// TokenFactory에 미등록된 컨트랙트의 dividendAddress 수동 매핑
+const DIVIDEND_ADDRESS_FALLBACK: Record<string, string> = {
+  '0x6f22dE7b12c17896Bb12ec88CCC9B7554c05b30c': '0x89644E13433f4e6Eb07aE42459929DcF906dAeA1',
+}
+
 // PropertyInfo 타입 정의
 export interface PropertyInfo {
   tokenAddress: string           // PropertyToken 주소
@@ -58,6 +63,20 @@ export const getPropertyInfoByTokenAddress = async (tokenAddress: string): Promi
         }
       }
     }
+    // TokenFactory에 없으면 fallback 매핑에서 찾기
+    const fallbackDividend = DIVIDEND_ADDRESS_FALLBACK[tokenAddress]
+    if (fallbackDividend) {
+      return {
+        tokenAddress,
+        dividendAddress: fallbackDividend,
+        governanceAddress: '0x0000000000000000000000000000000000000000',
+        propertyId: '0',
+        totalSupply: '0',
+        tokenPrice: '0',
+        initialized: true,
+      }
+    }
+
     return null
   } catch (error) {
     console.error('TokenAddress로 Property 정보 조회 실패:', error)

--- a/frontend_v2/src/apis/blockchain/contracts/tokenFactory.ts
+++ b/frontend_v2/src/apis/blockchain/contracts/tokenFactory.ts
@@ -22,26 +22,45 @@ export const getTokenFactoryContract = async (): Promise<Contract> => {
   return new Contract(TOKEN_FACTORY_ADDRESS, TOKEN_FACTORY_ABI, provider)
 }
 
-// Property 정보 가져오기
+// 숫자 인덱스로 Property 정보 가져오기 (TokenFactory는 uint256 인덱스 기반)
 export const getPropertyInfo = async (propertyId: string): Promise<PropertyInfo> => {
+  const contract = await getTokenFactoryContract()
+  const result = await contract.getProperty(propertyId)
+
+  return {
+    tokenAddress: result[3],
+    dividendAddress: result[5],
+    governanceAddress: result[6],
+    propertyId: result[0].toString(),
+    totalSupply: result[8].toString(),
+    tokenPrice: result[9].toString(),
+    initialized: result[11],
+  }
+}
+
+// PropertyToken 컨트랙트 주소로 역방향 조회
+export const getPropertyInfoByTokenAddress = async (tokenAddress: string): Promise<PropertyInfo | null> => {
   try {
     const contract = await getTokenFactoryContract()
-    const result = await contract.getProperty(propertyId)
+    const count = Number(await contract.getPropertyCount())
 
-    console.log('🔍 propertyId:', propertyId)
-    console.log('🔍 result:', result)
-
-    return {
-      tokenAddress: result[3],           // tokenAddress
-      dividendAddress: result[5],        // dividendAddress ← 우리가 원하는 주소!
-      governanceAddress: result[6],      // governanceAddress
-      propertyId: result[0].toString(),  // propertyId
-      totalSupply: result[8].toString(), // maxSupply
-      tokenPrice: result[9].toString(),  // tokenPrice
-      initialized: result[11]            // active
+    for (let i = 1; i <= count; i++) {
+      const result = await contract.getProperty(i)
+      if (result[3].toLowerCase() === tokenAddress.toLowerCase()) {
+        return {
+          tokenAddress: result[3],
+          dividendAddress: result[5],
+          governanceAddress: result[6],
+          propertyId: result[0].toString(),
+          totalSupply: result[8].toString(),
+          tokenPrice: result[9].toString(),
+          initialized: result[11],
+        }
+      }
     }
+    return null
   } catch (error) {
-    console.error('Property 정보 조회 실패:', error)
-    throw error
+    console.error('TokenAddress로 Property 정보 조회 실패:', error)
+    return null
   }
 }

--- a/frontend_v2/src/components/marketplace/PropertyCard.tsx
+++ b/frontend_v2/src/components/marketplace/PropertyCard.tsx
@@ -133,7 +133,7 @@ export default function PropertyCard({
 
         <div className="mt-auto">
           <div className="flex justify-between text-xs text-gray-400 mb-1.5">
-            <span>잔여 {remainingSupply ? Number(remainingSupply).toLocaleString() : '0'} {symbol} </span>
+            <span>잔여 {remainingSupply ? (Number(BigInt(remainingSupply) / BigInt(10 ** 18))).toLocaleString() : '0'} {symbol} </span>
             <span>{actualFundingPercentage.toFixed(1)}% 펀딩됨</span>
           </div>
           <div className="h-1.5 w-full overflow-hidden rounded-full bg-gray-600">

--- a/frontend_v2/src/components/portfolio/ClaimHistoryPanel.tsx
+++ b/frontend_v2/src/components/portfolio/ClaimHistoryPanel.tsx
@@ -7,6 +7,8 @@ import {
   isClaimedDividend,
   claimDividend
 } from '../../apis/blockchain/contracts/dividendDistributor'
+import { getBalanceAtSnapshot } from '../../apis/blockchain/contracts/propertyToken'
+import { getWalletAddress } from '../../apis/blockchain/provider'
 
 interface ClaimRecord {
   dividendId: number
@@ -53,6 +55,7 @@ export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: C
 
         // 2. 모든 배당 ID 가져오기
         const dividendIds = await getDividendIds(dividendAddress)
+        const userAddress = await getWalletAddress()
 
         // 3. 각 배당 정보 + 내 수령 가능 금액 병렬 조회
         const records: ClaimRecord[] = await Promise.all(
@@ -67,7 +70,22 @@ export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: C
             const date = new Date(Number(info.timestamp) * 1000)
             const month = `${date.getFullYear()}년 ${date.getMonth() + 1}월`
             const totalAmount = Number(BigInt(info.totalAmount) / BigInt(10 ** 18))
-            const myClaimable = Number(BigInt(myClaimableRaw) / BigInt(10 ** 18))
+
+            // 이미 클레임한 배당금은 getClaimableDividend가 0을 반환하므로
+            // dividendPerToken × balanceOfAt(snapshotId)로 직접 계산
+            let myClaimable: number
+            if (isClaimed && Number(info.snapshotId) > 0) {
+              try {
+                const balanceAtSnapshot = await getBalanceAtSnapshot(asset.id, userAddress, Number(info.snapshotId))
+                const PRECISION = BigInt(10 ** 18)
+                const wei = BigInt(info.dividendPerToken) * BigInt(balanceAtSnapshot) / PRECISION
+                myClaimable = Number(wei) / 10 ** 18
+              } catch {
+                myClaimable = 0
+              }
+            } else {
+              myClaimable = Number(BigInt(myClaimableRaw) / BigInt(10 ** 18))
+            }
 
             let status: ClaimRecord['status']
             if (isClaimed) {

--- a/frontend_v2/src/components/portfolio/ClaimHistoryPanel.tsx
+++ b/frontend_v2/src/components/portfolio/ClaimHistoryPanel.tsx
@@ -1,18 +1,19 @@
 import { useState, useEffect } from 'react'
-import { getPropertyInfo } from '../../apis/blockchain/contracts/tokenFactory'
+import { getPropertyInfoByTokenAddress } from '../../apis/blockchain/contracts/tokenFactory'
 import {
   getDividendIds,
   getDividendInfo,
+  getClaimableDividend,
   isClaimedDividend,
   claimDividend
 } from '../../apis/blockchain/contracts/dividendDistributor'
 
-
 interface ClaimRecord {
   dividendId: number
   month: string
-  amount: number
-  status: 'claimed' | 'unclaimed'
+  totalAmount: number       // 전체 배당 금액 (KRWT)
+  myClaimable: number       // 내가 받을 수 있는 금액 (KRWT)
+  status: 'unclaimed' | 'claimed' | 'expired'
   claimedDate?: string
   txHash?: string
 }
@@ -21,10 +22,9 @@ interface ClaimHistoryPanelProps {
   isOpen: boolean
   onClose: () => void
   asset: {
-    id: string //propertyId
+    id: string
     name: string
     image?: string
-    //unclaimedRewards: number
   } | null
   onClaim: (month: string, amount: number) => void
 }
@@ -32,40 +32,65 @@ interface ClaimHistoryPanelProps {
 export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: ClaimHistoryPanelProps) {
   const [claimRecords, setClaimRecords] = useState<ClaimRecord[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  const [claimingId, setClaimingId] = useState<number | null>(null)
+  const [claimError, setClaimError] = useState<string | null>(null)
 
   useEffect(() => {
-    const loadClaimHistory = async () => {
-      if (!asset || !isOpen) return
+    if (!asset || !isOpen) return
 
+    const loadClaimHistory = async () => {
       try {
         setIsLoading(true)
+        setClaimRecords([])
 
-        // 1. TokenFactory에서 dividendAddress 가져오기
-        const propertyInfo = await getPropertyInfo('3') //asset.id인데,,  테스트용 하드코딩
+        // 1. TokenFactory에서 dividendAddress 가져오기 (tokenAddress 역방향 조회)
+        const propertyInfo = await getPropertyInfoByTokenAddress(asset.id)
+        if (!propertyInfo || propertyInfo.dividendAddress === '0x0000000000000000000000000000000000000000') {
+          console.warn('DividendDistributor 주소를 찾을 수 없습니다:', asset.id)
+          return
+        }
         const dividendAddress = propertyInfo.dividendAddress
 
         // 2. 모든 배당 ID 가져오기
         const dividendIds = await getDividendIds(dividendAddress)
 
-        // 3. 각 배당 정보 조회
-        const records: ClaimRecord[] = []
-        for (const id of dividendIds) {
-          const info = await getDividendInfo(dividendAddress, Number(id))
-          const isClaimed = await isClaimedDividend(dividendAddress, Number(id))
+        // 3. 각 배당 정보 + 내 수령 가능 금액 병렬 조회
+        const records: ClaimRecord[] = await Promise.all(
+          dividendIds.map(async (id) => {
+            const dividendId = Number(id)
+            const [info, myClaimableRaw, isClaimed] = await Promise.all([
+              getDividendInfo(dividendAddress, dividendId),
+              getClaimableDividend(dividendAddress, dividendId),
+              isClaimedDividend(dividendAddress, dividendId),
+            ])
 
-          // timestamp를 날짜 문자열로 변환
-          const date = new Date(Number(info.timestamp) * 1000)
-          const month = `${date.getFullYear()}년 ${date.getMonth() + 1}월`
+            const date = new Date(Number(info.timestamp) * 1000)
+            const month = `${date.getFullYear()}년 ${date.getMonth() + 1}월`
+            const totalAmount = Number(BigInt(info.totalAmount) / BigInt(10 ** 18))
+            const myClaimable = Number(BigInt(myClaimableRaw) / BigInt(10 ** 18))
 
-          records.push({
-            dividendId: Number(id),
-            month: month,
-            amount: Number(info.totalAmount),
-            status: isClaimed ? 'claimed' : 'unclaimed',
-            claimedDate: isClaimed ? date.toLocaleDateString('ko-KR') : undefined
+            let status: ClaimRecord['status']
+            if (isClaimed) {
+              status = 'claimed'
+            } else if (!info.active) {
+              status = 'expired'
+            } else {
+              status = 'unclaimed'
+            }
+
+            return {
+              dividendId,
+              month,
+              totalAmount,
+              myClaimable,
+              status,
+              claimedDate: isClaimed ? date.toLocaleDateString('ko-KR') : undefined,
+            }
           })
-        }
+        )
 
+        // 최신순 정렬
+        records.sort((a, b) => b.dividendId - a.dividendId)
         setClaimRecords(records)
       } catch (error) {
         console.error('클레임 내역 로드 실패:', error)
@@ -75,48 +100,47 @@ export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: C
     }
 
     loadClaimHistory()
-  }, [asset, isOpen])
+  }, [asset?.id, isOpen])
 
-  const totalClaimed = claimRecords
-    .filter(record => record.status === 'claimed')
-    .reduce((sum, record) => sum + record.amount, 0)
+  const totalMyClaimed = claimRecords
+    .filter(r => r.status === 'claimed')
+    .reduce((sum, r) => sum + r.myClaimable, 0)
 
-  const totalUnclaimed = claimRecords
-    .filter(record => record.status === 'unclaimed')
-    .reduce((sum, record) => sum + record.amount, 0)
+  const totalMyUnclaimed = claimRecords
+    .filter(r => r.status === 'unclaimed')
+    .reduce((sum, r) => sum + r.myClaimable, 0)
 
   const handleClaimClick = async (dividendId: number, month: string, amount: number) => {
-      try {
-        setIsLoading(true)
-
-        // 1. dividendAddress 가져오기
-        const propertyInfo = await getPropertyInfo('3') //asset.id인데,,  테스트용 하드코딩
-
-        // 2. 배당금 청구
-        const txHash = await claimDividend(propertyInfo.dividendAddress, dividendId)
-
-        alert(`클레임 성공!\n트랜잭션: ${txHash}`)
-
-        // 3. 데이터 새로고침 - useEffect 다시 실행시키기 위해
-        // 여기서는 수동으로 해당 record 업데이트
-        setClaimRecords(prev =>
-          prev.map(r =>
-            r.dividendId === dividendId
-              ? { ...r, status: 'claimed' as const, claimedDate: new Date().toLocaleDateString('ko-KR'), txHash }
-              : r
-          )
-        )
-
-        // 4. 부모 콜백 실행
-        onClaim(month, amount)
-      } catch (error) {
-        console.error('클레임 실패:', error)
-        alert('클레임에 실패했습니다: ' + (error as Error).message)
-      } finally {
-        setIsLoading(false)
+    if (!asset) return
+    setClaimingId(dividendId)
+    setClaimError(null)
+    try {
+      const propertyInfo = await getPropertyInfoByTokenAddress(asset.id)
+      if (!propertyInfo || propertyInfo.dividendAddress === '0x0000000000000000000000000000000000000000') {
+        setClaimError('배당 컨트랙트 주소를 찾을 수 없습니다.')
+        return
       }
-    }
+      const txHash = await claimDividend(propertyInfo.dividendAddress, dividendId)
 
+      setClaimRecords(prev =>
+        prev.map(r =>
+          r.dividendId === dividendId
+            ? { ...r, status: 'claimed' as const, claimedDate: new Date().toLocaleDateString('ko-KR'), txHash }
+            : r
+        )
+      )
+      onClaim(month, amount)
+    } catch (err: unknown) {
+      const e = err as { code?: number | string; message?: string; reason?: string }
+      if (e.code === 4001 || e.code === 'ACTION_REJECTED') {
+        setClaimError('서명이 거부되었습니다.')
+      } else {
+        setClaimError('클레임 중 오류가 발생했습니다. 다시 시도해주세요.')
+      }
+    } finally {
+      setClaimingId(null)
+    }
+  }
 
   if (!asset) return null
 
@@ -168,33 +192,41 @@ export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: C
           <div className="grid grid-cols-2 gap-4 mb-8">
             <div className="bg-gray-800 border border-gray-600 rounded-xl p-5">
               <p className="text-sm text-gray-400 mb-2">총 수령한 수익</p>
-              <p className="text-2xl font-bold text-white">{totalClaimed.toLocaleString()} KRWT</p>
+              <p className="text-2xl font-bold text-white">KRWT {totalMyClaimed.toLocaleString()}</p>
             </div>
             <div className="bg-linear-to-br from-gray-800 to-[#1ABCF7]/5 border border-[#1ABCF7]/30 rounded-xl p-5">
               <p className="text-sm text-gray-400 mb-2">미수령 수익</p>
               <p className="text-2xl font-bold text-[#1ABCF7] drop-shadow-[0_0_10px_rgba(26,188,247,0.5)]">
-                {totalUnclaimed.toLocaleString()} KRWT
+                KRWT {totalMyUnclaimed.toLocaleString()}
               </p>
             </div>
           </div>
+
+          {/* Error Banner */}
+          {claimError && (
+            <div className="mb-4 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+              {claimError}
+            </div>
+          )}
 
           {/* Claim Records */}
           <div>
             <h3 className="text-xl font-bold text-white mb-4">클레임 내역</h3>
             <div className="space-y-3">
               {isLoading && (
-                <div className="text-center py-8">
-                  <p className="text-gray-400">블록체인 데이터 로딩중...</p>
+                <div className="flex items-center justify-center py-8 gap-3 text-gray-400">
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-[#1ABCF7]"></div>
+                  블록체인 데이터 로딩중...
                 </div>
               )}
               {!isLoading && claimRecords.length === 0 && (
                 <div className="text-center py-8">
-                  <p className="text-gray-400">클레임 내역이 없습니다.</p>
+                  <p className="text-gray-400">배당 내역이 없습니다.</p>
                 </div>
               )}
-              {claimRecords.map((record, index) => (
+              {claimRecords.map((record) => (
                 <div
-                  key={index}
+                  key={record.dividendId}
                   className={`bg-gray-800 border rounded-xl p-5 transition-all ${
                     record.status === 'unclaimed'
                       ? 'border-[#1ABCF7]/30 shadow-[0_0_15px_rgba(26,188,247,0.1)]'
@@ -208,32 +240,53 @@ export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: C
                         {record.status === 'unclaimed' && (
                           <span className="flex h-2 w-2 rounded-full bg-[#1ABCF7] shadow-[0_0_5px_#1ABCF7] animate-pulse"></span>
                         )}
-                      </div>
-                      <div className="flex items-center gap-4">
-                        <p className="text-2xl font-bold text-white">{record.amount.toLocaleString()} KRWT</p>
-                        {record.status === 'claimed' && record.claimedDate && (
-                          <span className="text-xs text-gray-400">수령일: {record.claimedDate}</span>
+                        {record.status === 'expired' && (
+                          <span className="rounded-full bg-gray-700 px-2 py-0.5 text-xs text-gray-400">만료됨</span>
                         )}
                       </div>
+                      <div className="flex items-baseline gap-2">
+                        <p className="text-2xl font-bold text-white">KRWT {record.myClaimable.toLocaleString()}</p>
+                        <span className="text-xs text-gray-500">내 수령분</span>
+                      </div>
+                      {record.status === 'claimed' && record.claimedDate && (
+                        <span className="text-xs text-gray-400 mt-1 block">수령일: {record.claimedDate}</span>
+                      )}
                     </div>
 
                     <div className="ml-4">
                       {record.status === 'unclaimed' ? (
                         <button
-                          onClick={() => handleClaimClick(record.dividendId, record.month, record.amount)}
-                          className="cursor-pointer flex items-center gap-2 rounded-lg bg-[#1ABCF7] px-6 py-3 text-sm font-bold text-black shadow-[0_0_10px_rgba(26,188,247,0.3)] transition-all hover:bg-white hover:shadow-[0_0_15px_rgba(255,255,255,0.4)]"
+                          onClick={() => handleClaimClick(record.dividendId, record.month, record.myClaimable)}
+                          disabled={claimingId === record.dividendId}
+                          className="cursor-pointer flex items-center gap-2 rounded-lg bg-[#1ABCF7] px-6 py-3 text-sm font-bold text-black shadow-[0_0_10px_rgba(26,188,247,0.3)] transition-all hover:bg-white hover:shadow-[0_0_15px_rgba(255,255,255,0.4)] disabled:opacity-50 disabled:cursor-not-allowed"
                         >
-                          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                            <path fillRule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clipRule="evenodd" />
-                          </svg>
-                          클레임 받기
+                          {claimingId === record.dividendId ? (
+                            <>
+                              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-black"></div>
+                              처리중
+                            </>
+                          ) : (
+                            <>
+                              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                <path fillRule="evenodd" d="M5 2a1 1 0 011 1v1h1a1 1 0 010 2H6v1a1 1 0 01-2 0V6H3a1 1 0 010-2h1V3a1 1 0 011-1zm0 10a1 1 0 011 1v1h1a1 1 0 110 2H6v1a1 1 0 11-2 0v-1H3a1 1 0 110-2h1v-1a1 1 0 011-1zM12 2a1 1 0 01.967.744L14.146 7.2 17.5 9.134a1 1 0 010 1.732l-3.354 1.935-1.18 4.455a1 1 0 01-1.933 0L9.854 12.8 6.5 10.866a1 1 0 010-1.732l3.354-1.935 1.18-4.455A1 1 0 0112 2z" clipRule="evenodd" />
+                              </svg>
+                              클레임 받기
+                            </>
+                          )}
                         </button>
-                      ) : (
+                      ) : record.status === 'claimed' ? (
                         <div className="flex items-center gap-2 text-green-400">
                           <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                           </svg>
                           <span className="text-sm font-medium">완료</span>
+                        </div>
+                      ) : (
+                        <div className="flex items-center gap-2 text-gray-500">
+                          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
+                          </svg>
+                          <span className="text-sm font-medium">만료</span>
                         </div>
                       )}
                     </div>
@@ -254,6 +307,7 @@ export default function ClaimHistoryPanel({ isOpen, onClose, asset, onClaim }: C
                 <ul className="space-y-1 text-gray-400">
                   <li>• 클레임은 발생 후 언제든지 가능합니다.</li>
                   <li>• 클레임 시 가스비가 발생할 수 있습니다.</li>
+                  <li>• 만료된 배당은 컨트랙트 오너가 회수한 상태입니다.</li>
                 </ul>
               </div>
             </div>

--- a/frontend_v2/src/pages/Marketplace.tsx
+++ b/frontend_v2/src/pages/Marketplace.tsx
@@ -298,8 +298,13 @@ export default function Marketplace() {
                   totalSupply={blockchainData[property.id]?.totalSupply}
                   maxSupply={blockchainData[property.id]?.maxSupply}
                   remainingSupply={blockchainData[property.id]?.remainingSupply || '0'}
-                  symbol={blockchainData[property.id]?.symbol || ''}
+                  symbol={blockchainData[property.id]?.symbol || 'STO'}
                   {...property}
+                  stoPrice={
+                    blockchainData[property.id]?.tokenPrice
+                      ? Number(blockchainData[property.id].tokenPrice)
+                      : property.stoPrice
+                  }
                   onClick={() => handlePropertyClick(property)}
                   onPurchaseClick={() => handlePurchaseClick(property)}
                 />

--- a/frontend_v2/src/pages/Portfolio.tsx
+++ b/frontend_v2/src/pages/Portfolio.tsx
@@ -6,6 +6,7 @@ import ClaimHistoryPanel from '../components/portfolio/ClaimHistoryPanel'
 import { getPortfolio, type PropertyResponse } from '../apis/properties'
 import { getPropertyInfoByTokenAddress } from '../apis/blockchain/contracts/tokenFactory'
 import { getTotalClaimable } from '../apis/blockchain/contracts/dividendDistributor'
+import { getPropertyBasicInfo } from '../apis/blockchain/contracts/propertyToken'
 
 interface Asset {
   id: string
@@ -37,16 +38,31 @@ export default function Portfolio() {
         const transformedAssets: Asset[] = await Promise.all(
           holdings.map(async (holding) => {
             let unclaimedRewards = 0
+            let currentValue = holding.property.pricePerToken * holding.amount
+            let symbol = 'STO'
 
-            try {
-              const propertyInfo = await getPropertyInfoByTokenAddress(holding.property.id)
-              if (propertyInfo && propertyInfo.dividendAddress !== '0x0000000000000000000000000000000000000000') {
-                const totalClaimable = await getTotalClaimable(propertyInfo.dividendAddress)
-                unclaimedRewards = Number(BigInt(totalClaimable) / BigInt(10 ** 18))
+            const isEthAddress = /^0x[0-9a-fA-F]{40}$/.test(holding.property.id)
+
+            if (isEthAddress) {
+              // 토큰 가격 + 심볼 (PropertyToken 직접 조회)
+              try {
+                const tokenInfo = await getPropertyBasicInfo(holding.property.id)
+                currentValue = Number(tokenInfo.tokenPrice) * holding.amount
+                symbol = tokenInfo.symbol || 'STO'
+              } catch (error) {
+                console.error(`${holding.property.name} 토큰 정보 조회 실패:`, error)
               }
-            } catch (error) {
-              console.error(`${holding.property.name} 미수령 수익 조회 실패:`, error)
-              unclaimedRewards = 0
+
+              // 미수령 배당금 (TokenFactory → DividendDistributor)
+              try {
+                const propertyInfo = await getPropertyInfoByTokenAddress(holding.property.id)
+                if (propertyInfo && propertyInfo.dividendAddress !== '0x0000000000000000000000000000000000000000') {
+                  const totalClaimable = await getTotalClaimable(propertyInfo.dividendAddress)
+                  unclaimedRewards = Number(BigInt(totalClaimable) / BigInt(10 ** 18))
+                }
+              } catch (error) {
+                console.error(`${holding.property.name} 미수령 수익 조회 실패:`, error)
+              }
             }
 
             return {
@@ -56,9 +72,9 @@ export default function Portfolio() {
               image: holding.property.coverImageUrl,
               status: holding.property.status === 'ACTIVE' ? 'active' : 'preparing',
               holdingAmount: holding.amount,
-              currentValue: holding.property.pricePerToken * holding.amount,
-              unclaimedRewards: unclaimedRewards, // 블록체인에서 가져온 실제 값
-              symbol: 'NPT', // TODO: API에서 symbol 추가 필요
+              currentValue,
+              unclaimedRewards,
+              symbol,
               propertyData: holding.property,
             }
           })

--- a/frontend_v2/src/pages/Portfolio.tsx
+++ b/frontend_v2/src/pages/Portfolio.tsx
@@ -4,7 +4,7 @@ import PortfolioAssetCard from '../components/portfolio/PortfolioAssetCard'
 import PortfolioDetailPanel from '../components/portfolio/PortfolioDetailPanel'
 import ClaimHistoryPanel from '../components/portfolio/ClaimHistoryPanel'
 import { getPortfolio, type PropertyResponse } from '../apis/properties'
-import { getPropertyInfo } from '../apis/blockchain/contracts/tokenFactory'
+import { getPropertyInfoByTokenAddress } from '../apis/blockchain/contracts/tokenFactory'
 import { getTotalClaimable } from '../apis/blockchain/contracts/dividendDistributor'
 
 interface Asset {
@@ -39,15 +39,14 @@ export default function Portfolio() {
             let unclaimedRewards = 0
 
             try {
-              // TokenFactory에서 dividendAddress 가져오기
-              const propertyInfo = await getPropertyInfo('3') // TODO: 실제 propertyId 사용해야 함
-
-              // DividendDistributor에서 미수령 배당금 조회
-              const totalClaimable = await getTotalClaimable(propertyInfo.dividendAddress)
-              unclaimedRewards = Number(totalClaimable)
+              const propertyInfo = await getPropertyInfoByTokenAddress(holding.property.id)
+              if (propertyInfo && propertyInfo.dividendAddress !== '0x0000000000000000000000000000000000000000') {
+                const totalClaimable = await getTotalClaimable(propertyInfo.dividendAddress)
+                unclaimedRewards = Number(BigInt(totalClaimable) / BigInt(10 ** 18))
+              }
             } catch (error) {
               console.error(`${holding.property.name} 미수령 수익 조회 실패:`, error)
-              unclaimedRewards = 0 // 실패하면 0으로 설정
+              unclaimedRewards = 0
             }
 
             return {
@@ -102,9 +101,8 @@ export default function Portfolio() {
     setTimeout(() => setClaimAsset(null), 300)
   }
 
-  const handleClaimMonth = (month: string, amount: number) => {
-    alert(`${month} 수익 KRWT${amount.toLocaleString()}를 클레임합니다!`)
-    // TODO: 실제 클레임 로직 구현
+  const handleClaimMonth = (_month: string, _amount: number) => {
+    // ClaimHistoryPanel 내부에서 처리
   }
 
   const handleDetailPanelClaim = () => {


### PR DESCRIPTION
## 📋 PR 유형
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정

<br/>

## 📕 작업 내역
### 작업 목록
배당(클레임) 기능 전반을 블록체인과 실제 연동하고, 관련 버그를 수정합니다.

 **[FEAT] 배당 클레임 블록체인 연동 - TokenFactory 역방향 주소 조회**   
   - `ClaimHistoryPanel`에서 `tokenAddress → dividendAddress` 역방향      
   조회 구현
   - `getDividendIds`, `getDividendInfo`, `getClaimableDividend`,
   `isClaimedDividend`, `claimDividend` 온체인 함수로 클레임 내역 로드    
   - 배당 ID별 수령 가능 금액, 상태(미수령/수령완료/만료) 표시

   **[FEAT] Marketplace/Portfolio 블록체인 데이터 연동 강화**
   - `tokenPrice`, `symbol`, `remainingSupply`를 DB 값 대신
   온체인(`PropertyToken`) 실시간 값으로 교체
   - `getPropertyBasicInfo` 병렬 조회로 Marketplace 카드 및 Portfolio     
   자산 데이터 갱신

   **[FIX] 배당 클레임 에러 처리 - 오버플로우 방어 및 fallback 추가**     
   - `getUnclaimedAmount` 오버플로우 시 `try/catch`로 0 처리
   - `dividendAddress`가 `0x000...000`이면 안전하게 스킵하는 fallback     
   추가

   **[FIX] 클레임 내역 패널 재오픈 시 수령금액 0 표시 버그 수정**
   - 이미 클레임된 배당금은 `getClaimableDividend`가 0을 반환하는 문제    
   - `dividendPerToken × balanceOfAt(snapshotId)`로 역산하여 올바른       
   금액 표시
   - `getBalanceAtSnapshot(tokenAddress, userAddress, snapshotId)` 헬퍼   
    함수 추가
  <br/>


## 🔧 앞으로의 과제
- 

## 🚨 참고 사항
-